### PR TITLE
Feature/toggle parameters

### DIFF
--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -29,6 +29,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _smoothMovement;
         private SerializedProperty _lookAtMe;
         private SerializedProperty _autoLevelRoll;
+        private SerializedProperty _autoLevelPitch;
 
         private void OnEnable()
         {
@@ -54,6 +55,7 @@ namespace VRCCamera.Editor
             _smoothMovement = serializedObject.FindProperty("smoothMovement");
             _lookAtMe = serializedObject.FindProperty("lookAtMe");
             _autoLevelRoll = serializedObject.FindProperty("autoLevelRoll");
+            _autoLevelPitch = serializedObject.FindProperty("autoLevelPitch");
         }
 
         public override void OnInspectorGUI()
@@ -77,6 +79,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_smoothMovement, new GUIContent("Smooth Movement"));
             EditorGUILayout.PropertyField(_lookAtMe, new GUIContent("Look At Me"));
             EditorGUILayout.PropertyField(_autoLevelRoll, new GUIContent("Auto Level Roll"));
+            EditorGUILayout.PropertyField(_autoLevelPitch, new GUIContent("Auto Level Pitch"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -1,7 +1,6 @@
 using UnityEditor;
 using UnityEngine;
 using Parameters;
-using VRCCamera;
 
 namespace VRCCamera.Editor
 {

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -1,6 +1,7 @@
 using UnityEditor;
 using UnityEngine;
 using Parameters;
+using VRCCamera;
 
 namespace VRCCamera.Editor
 {
@@ -165,22 +166,22 @@ namespace VRCCamera.Editor
             
             // Get current camera values
             var component = (VRCCameraSynchronizerComponent)target;
-            var camera = component.GetComponent<Camera>();
-            
-            if (camera != null)
+            var unityCamera = component.GetComponent<Camera>();
+
+            if (unityCamera != null)
             {
                 GUI.enabled = false; // Make read-only
                 
                 // Zoom (focal length) - clamp the display value
-                float clampedZoom = Mathf.Clamp(camera.focalLength, Zoom.MinValue, Zoom.MaxValue);
+                float clampedZoom = Mathf.Clamp(unityCamera.focalLength, Zoom.MinValue, Zoom.MaxValue);
                 EditorGUILayout.Slider("Zoom (Focal Length)", clampedZoom, Zoom.MinValue, Zoom.MaxValue);
                 
                 // Aperture - clamp the display value
-                float clampedAperture = Mathf.Clamp(camera.aperture, Aperture.MinValue, Aperture.MaxValue);
+                float clampedAperture = Mathf.Clamp(unityCamera.aperture, Aperture.MinValue, Aperture.MaxValue);
                 EditorGUILayout.Slider("Aperture", clampedAperture, Aperture.MinValue, Aperture.MaxValue);
                 
                 // Focal Distance - clamp the display value
-                float clampedFocalDistance = Mathf.Clamp(camera.focusDistance, FocalDistance.MinValue, FocalDistance.MaxValue);
+                float clampedFocalDistance = Mathf.Clamp(unityCamera.focusDistance, FocalDistance.MinValue, FocalDistance.MaxValue);
                 EditorGUILayout.Slider("Focal Distance", clampedFocalDistance, FocalDistance.MinValue, FocalDistance.MaxValue);
                 
                 GUI.enabled = true;

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -27,6 +27,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _environment;
         private SerializedProperty _greenScreen;
         private SerializedProperty _smoothMovement;
+        private SerializedProperty _lookAtMe;
 
         private void OnEnable()
         {
@@ -50,6 +51,7 @@ namespace VRCCamera.Editor
             _environment = serializedObject.FindProperty("environment");
             _greenScreen = serializedObject.FindProperty("greenScreen");
             _smoothMovement = serializedObject.FindProperty("smoothMovement");
+            _lookAtMe = serializedObject.FindProperty("lookAtMe");
         }
 
         public override void OnInspectorGUI()
@@ -71,6 +73,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.LabelField("Toggles", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(_lockCamera, new GUIContent("Lock"));
             EditorGUILayout.PropertyField(_smoothMovement, new GUIContent("Smooth Movement"));
+            EditorGUILayout.PropertyField(_lookAtMe, new GUIContent("Look At Me"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -21,6 +21,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _photoRate;
         private SerializedProperty _duration;
         private SerializedProperty _showUIInCamera;
+        private SerializedProperty _lockCamera;
 
         private void OnEnable()
         {
@@ -38,6 +39,7 @@ namespace VRCCamera.Editor
             _photoRate = serializedObject.FindProperty("photoRate");
             _duration = serializedObject.FindProperty("duration");
             _showUIInCamera = serializedObject.FindProperty("showUIInCamera");
+            _lockCamera = serializedObject.FindProperty("lockCamera");
         }
 
         public override void OnInspectorGUI()
@@ -58,6 +60,7 @@ namespace VRCCamera.Editor
             // Toggle Parameters
             EditorGUILayout.LabelField("Toggles", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("Show UI In Camera"));
+            EditorGUILayout.PropertyField(_lockCamera, new GUIContent("Lock"));
             
             EditorGUILayout.Space();
             

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -32,6 +32,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _autoLevelPitch;
         private SerializedProperty _flying;
         private SerializedProperty _triggerTakesPhotos;
+        private SerializedProperty _dollyPathsStayVisible;
 
         private void OnEnable()
         {
@@ -60,6 +61,7 @@ namespace VRCCamera.Editor
             _autoLevelPitch = serializedObject.FindProperty("autoLevelPitch");
             _flying = serializedObject.FindProperty("flying");
             _triggerTakesPhotos = serializedObject.FindProperty("triggerTakesPhotos");
+            _dollyPathsStayVisible = serializedObject.FindProperty("dollyPathsStayVisible");
         }
 
         public override void OnInspectorGUI()
@@ -86,6 +88,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_autoLevelPitch, new GUIContent("Auto Level Pitch"));
             EditorGUILayout.PropertyField(_flying, new GUIContent("Flying"));
             EditorGUILayout.PropertyField(_triggerTakesPhotos, new GUIContent("Trigger Takes Photos"));
+            EditorGUILayout.PropertyField(_dollyPathsStayVisible, new GUIContent("Dolly Paths Stay Visible"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -28,6 +28,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _greenScreen;
         private SerializedProperty _smoothMovement;
         private SerializedProperty _lookAtMe;
+        private SerializedProperty _autoLevelRoll;
 
         private void OnEnable()
         {
@@ -52,6 +53,7 @@ namespace VRCCamera.Editor
             _greenScreen = serializedObject.FindProperty("greenScreen");
             _smoothMovement = serializedObject.FindProperty("smoothMovement");
             _lookAtMe = serializedObject.FindProperty("lookAtMe");
+            _autoLevelRoll = serializedObject.FindProperty("autoLevelRoll");
         }
 
         public override void OnInspectorGUI()
@@ -74,6 +76,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_lockCamera, new GUIContent("Lock"));
             EditorGUILayout.PropertyField(_smoothMovement, new GUIContent("Smooth Movement"));
             EditorGUILayout.PropertyField(_lookAtMe, new GUIContent("Look At Me"));
+            EditorGUILayout.PropertyField(_autoLevelRoll, new GUIContent("Auto Level Roll"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -30,6 +30,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _lookAtMe;
         private SerializedProperty _autoLevelRoll;
         private SerializedProperty _autoLevelPitch;
+        private SerializedProperty _flying;
 
         private void OnEnable()
         {
@@ -56,6 +57,7 @@ namespace VRCCamera.Editor
             _lookAtMe = serializedObject.FindProperty("lookAtMe");
             _autoLevelRoll = serializedObject.FindProperty("autoLevelRoll");
             _autoLevelPitch = serializedObject.FindProperty("autoLevelPitch");
+            _flying = serializedObject.FindProperty("flying");
         }
 
         public override void OnInspectorGUI()
@@ -80,6 +82,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_lookAtMe, new GUIContent("Look At Me"));
             EditorGUILayout.PropertyField(_autoLevelRoll, new GUIContent("Auto Level Roll"));
             EditorGUILayout.PropertyField(_autoLevelPitch, new GUIContent("Auto Level Pitch"));
+            EditorGUILayout.PropertyField(_flying, new GUIContent("Flying"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -22,6 +22,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _duration;
         private SerializedProperty _showUIInCamera;
         private SerializedProperty _lockCamera;
+        private SerializedProperty _localPlayer;
 
         private void OnEnable()
         {
@@ -40,6 +41,7 @@ namespace VRCCamera.Editor
             _duration = serializedObject.FindProperty("duration");
             _showUIInCamera = serializedObject.FindProperty("showUIInCamera");
             _lockCamera = serializedObject.FindProperty("lockCamera");
+            _localPlayer = serializedObject.FindProperty("localPlayer");
         }
 
         public override void OnInspectorGUI()
@@ -59,8 +61,14 @@ namespace VRCCamera.Editor
             
             // Toggle Parameters
             EditorGUILayout.LabelField("Toggles", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("Show UI In Camera"));
             EditorGUILayout.PropertyField(_lockCamera, new GUIContent("Lock"));
+
+            EditorGUILayout.Space();
+
+            // Mask Parameters
+            EditorGUILayout.LabelField("Mask", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(_localPlayer, new GUIContent("Local User"));
+            EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("UI"));
             
             EditorGUILayout.Space();
             

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -20,6 +20,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _smoothingStrength;
         private SerializedProperty _photoRate;
         private SerializedProperty _duration;
+        private SerializedProperty _showUIInCamera;
 
         private void OnEnable()
         {
@@ -36,6 +37,7 @@ namespace VRCCamera.Editor
             _smoothingStrength = serializedObject.FindProperty("smoothingStrength");
             _photoRate = serializedObject.FindProperty("photoRate");
             _duration = serializedObject.FindProperty("duration");
+            _showUIInCamera = serializedObject.FindProperty("showUIInCamera");
         }
 
         public override void OnInspectorGUI()
@@ -50,6 +52,12 @@ namespace VRCCamera.Editor
 
             // Camera Parameters
             EditorGUILayout.Slider(_exposure, Exposure.MinValue, Exposure.MaxValue, "Exposure");
+            
+            EditorGUILayout.Space();
+            
+            // Toggle Parameters
+            EditorGUILayout.LabelField("Toggles", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("Show UI In Camera"));
             
             EditorGUILayout.Space();
             

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -31,6 +31,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _autoLevelRoll;
         private SerializedProperty _autoLevelPitch;
         private SerializedProperty _flying;
+        private SerializedProperty _triggerTakesPhotos;
 
         private void OnEnable()
         {
@@ -58,6 +59,7 @@ namespace VRCCamera.Editor
             _autoLevelRoll = serializedObject.FindProperty("autoLevelRoll");
             _autoLevelPitch = serializedObject.FindProperty("autoLevelPitch");
             _flying = serializedObject.FindProperty("flying");
+            _triggerTakesPhotos = serializedObject.FindProperty("triggerTakesPhotos");
         }
 
         public override void OnInspectorGUI()
@@ -83,6 +85,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_autoLevelRoll, new GUIContent("Auto Level Roll"));
             EditorGUILayout.PropertyField(_autoLevelPitch, new GUIContent("Auto Level Pitch"));
             EditorGUILayout.PropertyField(_flying, new GUIContent("Flying"));
+            EditorGUILayout.PropertyField(_triggerTakesPhotos, new GUIContent("Trigger Takes Photos"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -23,6 +23,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _showUIInCamera;
         private SerializedProperty _lockCamera;
         private SerializedProperty _localPlayer;
+        private SerializedProperty _remotePlayer;
 
         private void OnEnable()
         {
@@ -42,6 +43,7 @@ namespace VRCCamera.Editor
             _showUIInCamera = serializedObject.FindProperty("showUIInCamera");
             _lockCamera = serializedObject.FindProperty("lockCamera");
             _localPlayer = serializedObject.FindProperty("localPlayer");
+            _remotePlayer = serializedObject.FindProperty("remotePlayer");
         }
 
         public override void OnInspectorGUI()
@@ -68,6 +70,7 @@ namespace VRCCamera.Editor
             // Mask Parameters
             EditorGUILayout.LabelField("Mask", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(_localPlayer, new GUIContent("Local User"));
+            EditorGUILayout.PropertyField(_remotePlayer, new GUIContent("Remote Users"));
             EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("UI"));
             
             EditorGUILayout.Space();

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -25,6 +25,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _localPlayer;
         private SerializedProperty _remotePlayer;
         private SerializedProperty _environment;
+        private SerializedProperty _greenScreen;
 
         private void OnEnable()
         {
@@ -46,6 +47,7 @@ namespace VRCCamera.Editor
             _localPlayer = serializedObject.FindProperty("localPlayer");
             _remotePlayer = serializedObject.FindProperty("remotePlayer");
             _environment = serializedObject.FindProperty("environment");
+            _greenScreen = serializedObject.FindProperty("greenScreen");
         }
 
         public override void OnInspectorGUI()
@@ -74,30 +76,27 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_localPlayer, new GUIContent("Local User"));
             EditorGUILayout.PropertyField(_remotePlayer, new GUIContent("Remote User"));
             EditorGUILayout.PropertyField(_environment, new GUIContent("World"));
-            EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("UI"));
-            
-            EditorGUILayout.Space();
-            
-            // GreenScreen Parameters
-            EditorGUILayout.LabelField("GreenScreen", EditorStyles.boldLabel);
-            
-            // Color picker only
-            // Map Lightness to V for display
-            Color currentColor = Color.HSVToRGB(
-                _hue.floatValue / Hue.MaxValue, 
+            EditorGUILayout.PropertyField(_greenScreen, new GUIContent("Green Screen"));
+            EditorGUI.indentLevel++;
+            // Color picker for Green Screen (Hue/Saturation/Lightness)
+            Color currentMaskColor = Color.HSVToRGB(
+                _hue.floatValue / Hue.MaxValue,
                 _saturation.floatValue / Saturation.MaxValue,
                 _lightness.floatValue / Lightness.MaxValue
             );
-            
             EditorGUI.BeginChangeCheck();
-            Color newColor = EditorGUILayout.ColorField("GreenScreen Color", currentColor);
+            Color newMaskColor = EditorGUILayout.ColorField("Color", currentMaskColor);
             if (EditorGUI.EndChangeCheck())
             {
-                Color.RGBToHSV(newColor, out float h, out float s, out float v);
+                Color.RGBToHSV(newMaskColor, out float h, out float s, out float v);
                 _hue.floatValue = h * Hue.MaxValue;
                 _saturation.floatValue = s * Saturation.MaxValue;
                 _lightness.floatValue = v * Lightness.MaxValue;
             }
+            EditorGUI.indentLevel--;
+            EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("UI"));
+            
+            EditorGUILayout.Space();
             
             EditorGUILayout.Space();
             

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -37,6 +37,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _showFocus;
         private SerializedProperty _streaming;
         private SerializedProperty _rollWhileFlying;
+        private SerializedProperty _orientationIsLandscape;
 
         private void OnEnable()
         {
@@ -70,6 +71,7 @@ namespace VRCCamera.Editor
             _showFocus = serializedObject.FindProperty("showFocus");
             _streaming = serializedObject.FindProperty("streaming");
             _rollWhileFlying = serializedObject.FindProperty("rollWhileFlying");
+            _orientationIsLandscape = serializedObject.FindProperty("orientationIsLandscape");
         }
 
         public override void OnInspectorGUI()
@@ -101,6 +103,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_showFocus, new GUIContent("Show Focus"));
             EditorGUILayout.PropertyField(_streaming, new GUIContent("Streaming"));
             EditorGUILayout.PropertyField(_rollWhileFlying, new GUIContent("Roll While Flying"));
+            EditorGUILayout.PropertyField(_orientationIsLandscape, new GUIContent("Orientation Is Landscape"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -34,6 +34,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _triggerTakesPhotos;
         private SerializedProperty _dollyPathsStayVisible;
         private SerializedProperty _cameraEars;
+        private SerializedProperty _showFocus;
 
         private void OnEnable()
         {
@@ -64,6 +65,7 @@ namespace VRCCamera.Editor
             _triggerTakesPhotos = serializedObject.FindProperty("triggerTakesPhotos");
             _dollyPathsStayVisible = serializedObject.FindProperty("dollyPathsStayVisible");
             _cameraEars = serializedObject.FindProperty("cameraEars");
+            _showFocus = serializedObject.FindProperty("showFocus");
         }
 
         public override void OnInspectorGUI()
@@ -92,6 +94,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_triggerTakesPhotos, new GUIContent("Trigger Takes Photos"));
             EditorGUILayout.PropertyField(_dollyPathsStayVisible, new GUIContent("Dolly Paths Stay Visible"));
             EditorGUILayout.PropertyField(_cameraEars, new GUIContent("Camera Ears"));
+            EditorGUILayout.PropertyField(_showFocus, new GUIContent("Show Focus"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -24,6 +24,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _lockCamera;
         private SerializedProperty _localPlayer;
         private SerializedProperty _remotePlayer;
+        private SerializedProperty _environment;
 
         private void OnEnable()
         {
@@ -44,6 +45,7 @@ namespace VRCCamera.Editor
             _lockCamera = serializedObject.FindProperty("lockCamera");
             _localPlayer = serializedObject.FindProperty("localPlayer");
             _remotePlayer = serializedObject.FindProperty("remotePlayer");
+            _environment = serializedObject.FindProperty("environment");
         }
 
         public override void OnInspectorGUI()
@@ -70,7 +72,8 @@ namespace VRCCamera.Editor
             // Mask Parameters
             EditorGUILayout.LabelField("Mask", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(_localPlayer, new GUIContent("Local User"));
-            EditorGUILayout.PropertyField(_remotePlayer, new GUIContent("Remote Users"));
+            EditorGUILayout.PropertyField(_remotePlayer, new GUIContent("Remote User"));
+            EditorGUILayout.PropertyField(_environment, new GUIContent("World"));
             EditorGUILayout.PropertyField(_showUIInCamera, new GUIContent("UI"));
             
             EditorGUILayout.Space();

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -33,6 +33,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _flying;
         private SerializedProperty _triggerTakesPhotos;
         private SerializedProperty _dollyPathsStayVisible;
+        private SerializedProperty _cameraEars;
 
         private void OnEnable()
         {
@@ -62,6 +63,7 @@ namespace VRCCamera.Editor
             _flying = serializedObject.FindProperty("flying");
             _triggerTakesPhotos = serializedObject.FindProperty("triggerTakesPhotos");
             _dollyPathsStayVisible = serializedObject.FindProperty("dollyPathsStayVisible");
+            _cameraEars = serializedObject.FindProperty("cameraEars");
         }
 
         public override void OnInspectorGUI()
@@ -89,6 +91,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_flying, new GUIContent("Flying"));
             EditorGUILayout.PropertyField(_triggerTakesPhotos, new GUIContent("Trigger Takes Photos"));
             EditorGUILayout.PropertyField(_dollyPathsStayVisible, new GUIContent("Dolly Paths Stay Visible"));
+            EditorGUILayout.PropertyField(_cameraEars, new GUIContent("Camera Ears"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -26,6 +26,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _remotePlayer;
         private SerializedProperty _environment;
         private SerializedProperty _greenScreen;
+        private SerializedProperty _smoothMovement;
 
         private void OnEnable()
         {
@@ -48,6 +49,7 @@ namespace VRCCamera.Editor
             _remotePlayer = serializedObject.FindProperty("remotePlayer");
             _environment = serializedObject.FindProperty("environment");
             _greenScreen = serializedObject.FindProperty("greenScreen");
+            _smoothMovement = serializedObject.FindProperty("smoothMovement");
         }
 
         public override void OnInspectorGUI()
@@ -68,6 +70,7 @@ namespace VRCCamera.Editor
             // Toggle Parameters
             EditorGUILayout.LabelField("Toggles", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(_lockCamera, new GUIContent("Lock"));
+            EditorGUILayout.PropertyField(_smoothMovement, new GUIContent("Smooth Movement"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -36,6 +36,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _cameraEars;
         private SerializedProperty _showFocus;
         private SerializedProperty _streaming;
+        private SerializedProperty _rollWhileFlying;
 
         private void OnEnable()
         {
@@ -68,6 +69,7 @@ namespace VRCCamera.Editor
             _cameraEars = serializedObject.FindProperty("cameraEars");
             _showFocus = serializedObject.FindProperty("showFocus");
             _streaming = serializedObject.FindProperty("streaming");
+            _rollWhileFlying = serializedObject.FindProperty("rollWhileFlying");
         }
 
         public override void OnInspectorGUI()
@@ -98,6 +100,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_cameraEars, new GUIContent("Camera Ears"));
             EditorGUILayout.PropertyField(_showFocus, new GUIContent("Show Focus"));
             EditorGUILayout.PropertyField(_streaming, new GUIContent("Streaming"));
+            EditorGUILayout.PropertyField(_rollWhileFlying, new GUIContent("Roll While Flying"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -35,6 +35,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _dollyPathsStayVisible;
         private SerializedProperty _cameraEars;
         private SerializedProperty _showFocus;
+        private SerializedProperty _streaming;
 
         private void OnEnable()
         {
@@ -66,6 +67,7 @@ namespace VRCCamera.Editor
             _dollyPathsStayVisible = serializedObject.FindProperty("dollyPathsStayVisible");
             _cameraEars = serializedObject.FindProperty("cameraEars");
             _showFocus = serializedObject.FindProperty("showFocus");
+            _streaming = serializedObject.FindProperty("streaming");
         }
 
         public override void OnInspectorGUI()
@@ -95,6 +97,7 @@ namespace VRCCamera.Editor
             EditorGUILayout.PropertyField(_dollyPathsStayVisible, new GUIContent("Dolly Paths Stay Visible"));
             EditorGUILayout.PropertyField(_cameraEars, new GUIContent("Camera Ears"));
             EditorGUILayout.PropertyField(_showFocus, new GUIContent("Show Focus"));
+            EditorGUILayout.PropertyField(_streaming, new GUIContent("Streaming"));
 
             EditorGUILayout.Space();
 

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -34,6 +34,7 @@ namespace VRCCamera
         [SerializeField] private bool autoLevelPitch = false;
         [SerializeField] private bool flying = false;
         [SerializeField] private bool triggerTakesPhotos = false;
+        [SerializeField] private bool dollyPathsStayVisible = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -78,6 +79,7 @@ namespace VRCCamera
                 _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
                 _vrcCamera.SetFlying(new FlyingToggle(flying));
                 _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
+                _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -132,6 +134,7 @@ namespace VRCCamera
             _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
             _vrcCamera.SetFlying(new FlyingToggle(flying));
             _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
+            _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -25,6 +25,7 @@ namespace VRCCamera
         [SerializeField] private bool showUIInCamera = false;
         [SerializeField] private bool lockCamera = false;
         [SerializeField] private bool localPlayer = false;
+        [SerializeField] private bool remotePlayer = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -60,6 +61,7 @@ namespace VRCCamera
                 _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
                 _vrcCamera.SetLock(new LockToggle(lockCamera));
                 _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
+                _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -105,6 +107,7 @@ namespace VRCCamera
             _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
             _vrcCamera.SetLock(new LockToggle(lockCamera));
             _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
+            _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -35,6 +35,7 @@ namespace VRCCamera
         [SerializeField] private bool flying = false;
         [SerializeField] private bool triggerTakesPhotos = false;
         [SerializeField] private bool dollyPathsStayVisible = false;
+        [SerializeField] private bool cameraEars = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -80,6 +81,7 @@ namespace VRCCamera
                 _vrcCamera.SetFlying(new FlyingToggle(flying));
                 _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
                 _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
+                _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -135,6 +137,7 @@ namespace VRCCamera
             _vrcCamera.SetFlying(new FlyingToggle(flying));
             _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
             _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
+            _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -27,6 +27,7 @@ namespace VRCCamera
         [SerializeField] private bool localPlayer = false;
         [SerializeField] private bool remotePlayer = false;
         [SerializeField] private bool environment = false;
+        [SerializeField] private bool greenScreen = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -64,6 +65,7 @@ namespace VRCCamera
                 _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
                 _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
                 _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
+                _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -111,6 +113,7 @@ namespace VRCCamera
             _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
             _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
             _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
+            _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -28,6 +28,7 @@ namespace VRCCamera
         [SerializeField] private bool remotePlayer = false;
         [SerializeField] private bool environment = false;
         [SerializeField] private bool greenScreen = false;
+        [SerializeField] private bool smoothMovement = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -66,6 +67,7 @@ namespace VRCCamera
                 _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
                 _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
                 _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
+                _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -114,6 +116,7 @@ namespace VRCCamera
             _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
             _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
             _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
+            _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -38,6 +38,7 @@ namespace VRCCamera
         [SerializeField] private bool cameraEars = false;
         [SerializeField] private bool showFocus = false;
         [SerializeField] private bool streaming = false;
+        [SerializeField] private bool rollWhileFlying = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -86,6 +87,7 @@ namespace VRCCamera
                 _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
                 _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
                 _vrcCamera.SetStreaming(new StreamingToggle(streaming));
+                _vrcCamera.SetRollWhileFlying(new RollWhileFlyingToggle(rollWhileFlying));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -144,6 +146,7 @@ namespace VRCCamera
             _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
             _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
             _vrcCamera.SetStreaming(new StreamingToggle(streaming));
+            _vrcCamera.SetRollWhileFlying(new RollWhileFlyingToggle(rollWhileFlying));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -37,6 +37,7 @@ namespace VRCCamera
         [SerializeField] private bool dollyPathsStayVisible = false;
         [SerializeField] private bool cameraEars = false;
         [SerializeField] private bool showFocus = false;
+        [SerializeField] private bool streaming = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -84,6 +85,7 @@ namespace VRCCamera
                 _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
                 _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
                 _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
+                _vrcCamera.SetStreaming(new StreamingToggle(streaming));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -141,6 +143,7 @@ namespace VRCCamera
             _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
             _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
             _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
+            _vrcCamera.SetStreaming(new StreamingToggle(streaming));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -26,6 +26,7 @@ namespace VRCCamera
         [SerializeField] private bool lockCamera = false;
         [SerializeField] private bool localPlayer = false;
         [SerializeField] private bool remotePlayer = false;
+        [SerializeField] private bool environment = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -62,6 +63,7 @@ namespace VRCCamera
                 _vrcCamera.SetLock(new LockToggle(lockCamera));
                 _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
                 _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
+                _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -108,6 +110,7 @@ namespace VRCCamera
             _vrcCamera.SetLock(new LockToggle(lockCamera));
             _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
             _vrcCamera.SetRemotePlayer(new RemotePlayerToggle(remotePlayer));
+            _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -23,6 +23,7 @@ namespace VRCCamera
         [SerializeField] private float photoRate = PhotoRate.DefaultValue;
         [SerializeField] private float duration = Duration.DefaultValue;
         [SerializeField] private bool showUIInCamera = false;
+        [SerializeField] private bool lockCamera = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -56,6 +57,7 @@ namespace VRCCamera
                 _vrcCamera.SetPhotoRate(new PhotoRate(photoRate));
                 _vrcCamera.SetDuration(new Duration(duration));
                 _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
+                _vrcCamera.SetLock(new LockToggle(lockCamera));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -99,6 +101,7 @@ namespace VRCCamera
             _vrcCamera.SetPhotoRate(new PhotoRate(photoRate));
             _vrcCamera.SetDuration(new Duration(duration));
             _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
+            _vrcCamera.SetLock(new LockToggle(lockCamera));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -22,6 +22,7 @@ namespace VRCCamera
         [SerializeField] private float smoothingStrength = SmoothingStrength.DefaultValue;
         [SerializeField] private float photoRate = PhotoRate.DefaultValue;
         [SerializeField] private float duration = Duration.DefaultValue;
+        [SerializeField] private bool showUIInCamera = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -40,6 +41,22 @@ namespace VRCCamera
             try
             {
                 _vrcCamera = new VRCCamera(cameraComponent);
+                
+                // Set all initial values before creating synchronizer to avoid duplicate messages
+                _vrcCamera.SetExposure(new Exposure(exposure));
+                _vrcCamera.SetHue(new Hue(hue));
+                _vrcCamera.SetSaturation(new Saturation(saturation));
+                _vrcCamera.SetLightness(new Lightness(lightness));
+                _vrcCamera.SetLookAtMeOffset(new LookAtMeOffset(
+                    new LookAtMeXOffset(lookAtMeXOffset),
+                    new LookAtMeYOffset(lookAtMeYOffset)));
+                _vrcCamera.SetFlySpeed(new FlySpeed(flySpeed));
+                _vrcCamera.SetTurnSpeed(new TurnSpeed(turnSpeed));
+                _vrcCamera.SetSmoothingStrength(new SmoothingStrength(smoothingStrength));
+                _vrcCamera.SetPhotoRate(new PhotoRate(photoRate));
+                _vrcCamera.SetDuration(new Duration(duration));
+                _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
+                
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
             }
@@ -81,6 +98,7 @@ namespace VRCCamera
             _vrcCamera.SetSmoothingStrength(new SmoothingStrength(smoothingStrength));
             _vrcCamera.SetPhotoRate(new PhotoRate(photoRate));
             _vrcCamera.SetDuration(new Duration(duration));
+            _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -24,6 +24,7 @@ namespace VRCCamera
         [SerializeField] private float duration = Duration.DefaultValue;
         [SerializeField] private bool showUIInCamera = false;
         [SerializeField] private bool lockCamera = false;
+        [SerializeField] private bool localPlayer = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -58,6 +59,7 @@ namespace VRCCamera
                 _vrcCamera.SetDuration(new Duration(duration));
                 _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
                 _vrcCamera.SetLock(new LockToggle(lockCamera));
+                _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -102,6 +104,7 @@ namespace VRCCamera
             _vrcCamera.SetDuration(new Duration(duration));
             _vrcCamera.SetShowUIInCamera(new ShowUIInCameraToggle(showUIInCamera));
             _vrcCamera.SetLock(new LockToggle(lockCamera));
+            _vrcCamera.SetLocalPlayer(new LocalPlayerToggle(localPlayer));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -39,6 +39,7 @@ namespace VRCCamera
         [SerializeField] private bool showFocus = false;
         [SerializeField] private bool streaming = false;
         [SerializeField] private bool rollWhileFlying = false;
+        [SerializeField] private bool orientationIsLandscape = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -88,6 +89,7 @@ namespace VRCCamera
                 _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
                 _vrcCamera.SetStreaming(new StreamingToggle(streaming));
                 _vrcCamera.SetRollWhileFlying(new RollWhileFlyingToggle(rollWhileFlying));
+                _vrcCamera.SetOrientationIsLandscape(new OrientationIsLandscapeToggle(orientationIsLandscape));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -147,6 +149,7 @@ namespace VRCCamera
             _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
             _vrcCamera.SetStreaming(new StreamingToggle(streaming));
             _vrcCamera.SetRollWhileFlying(new RollWhileFlyingToggle(rollWhileFlying));
+            _vrcCamera.SetOrientationIsLandscape(new OrientationIsLandscapeToggle(orientationIsLandscape));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -49,7 +49,7 @@ namespace VRCCamera
             var cameraComponent = GetComponent<Camera>();
             if (!cameraComponent)
             {
-                Debug.LogError($"[{nameof(VRCCameraSynchronizer)}] Camera component is missing");
+                Debug.LogError($"[{nameof(VRCCameraSynchronizerComponent)}] Camera component is missing");
                 enabled = false;
                 return;
             }
@@ -98,7 +98,7 @@ namespace VRCCamera
             {
                 transmitter?.Dispose();
                 Debug.LogError(
-                    $"[{nameof(VRCCameraSynchronizer)}] Failed to initialize: {ex.Message}\n{ex.StackTrace}");
+                    $"[{nameof(VRCCameraSynchronizerComponent)}] Failed to initialize: {ex.Message}\n{ex.StackTrace}");
                 enabled = false;
             }
         }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -29,6 +29,7 @@ namespace VRCCamera
         [SerializeField] private bool environment = false;
         [SerializeField] private bool greenScreen = false;
         [SerializeField] private bool smoothMovement = false;
+        [SerializeField] private bool lookAtMe = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -68,6 +69,7 @@ namespace VRCCamera
                 _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
                 _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
                 _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
+                _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -117,6 +119,7 @@ namespace VRCCamera
             _vrcCamera.SetEnvironment(new EnvironmentToggle(environment));
             _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
             _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
+            _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -30,6 +30,7 @@ namespace VRCCamera
         [SerializeField] private bool greenScreen = false;
         [SerializeField] private bool smoothMovement = false;
         [SerializeField] private bool lookAtMe = false;
+        [SerializeField] private bool autoLevelRoll = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -70,6 +71,7 @@ namespace VRCCamera
                 _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
                 _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
                 _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
+                _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -120,6 +122,7 @@ namespace VRCCamera
             _vrcCamera.SetGreenScreen(new GreenScreenToggle(greenScreen));
             _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
             _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
+            _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -33,6 +33,7 @@ namespace VRCCamera
         [SerializeField] private bool autoLevelRoll = false;
         [SerializeField] private bool autoLevelPitch = false;
         [SerializeField] private bool flying = false;
+        [SerializeField] private bool triggerTakesPhotos = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -76,6 +77,7 @@ namespace VRCCamera
                 _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
                 _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
                 _vrcCamera.SetFlying(new FlyingToggle(flying));
+                _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -129,6 +131,7 @@ namespace VRCCamera
             _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
             _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
             _vrcCamera.SetFlying(new FlyingToggle(flying));
+            _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -36,6 +36,7 @@ namespace VRCCamera
         [SerializeField] private bool triggerTakesPhotos = false;
         [SerializeField] private bool dollyPathsStayVisible = false;
         [SerializeField] private bool cameraEars = false;
+        [SerializeField] private bool showFocus = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -82,6 +83,7 @@ namespace VRCCamera
                 _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
                 _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
                 _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
+                _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -138,6 +140,7 @@ namespace VRCCamera
             _vrcCamera.SetTriggerTakesPhotos(new TriggerTakesPhotosToggle(triggerTakesPhotos));
             _vrcCamera.SetDollyPathsStayVisible(new DollyPathsStayVisibleToggle(dollyPathsStayVisible));
             _vrcCamera.SetCameraEars(new CameraEarsToggle(cameraEars));
+            _vrcCamera.SetShowFocus(new ShowFocusToggle(showFocus));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -32,6 +32,7 @@ namespace VRCCamera
         [SerializeField] private bool lookAtMe = false;
         [SerializeField] private bool autoLevelRoll = false;
         [SerializeField] private bool autoLevelPitch = false;
+        [SerializeField] private bool flying = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -74,6 +75,7 @@ namespace VRCCamera
                 _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
                 _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
                 _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
+                _vrcCamera.SetFlying(new FlyingToggle(flying));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -126,6 +128,7 @@ namespace VRCCamera
             _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
             _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
             _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
+            _vrcCamera.SetFlying(new FlyingToggle(flying));
         }
     }
 }

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -31,6 +31,7 @@ namespace VRCCamera
         [SerializeField] private bool smoothMovement = false;
         [SerializeField] private bool lookAtMe = false;
         [SerializeField] private bool autoLevelRoll = false;
+        [SerializeField] private bool autoLevelPitch = false;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -72,6 +73,7 @@ namespace VRCCamera
                 _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
                 _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
                 _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
+                _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -123,6 +125,7 @@ namespace VRCCamera
             _vrcCamera.SetSmoothMovement(new SmoothMovementToggle(smoothMovement));
             _vrcCamera.SetLookAtMe(new LookAtMeToggle(lookAtMe));
             _vrcCamera.SetAutoLevelRoll(new AutoLevelRollToggle(autoLevelRoll));
+            _vrcCamera.SetAutoLevelPitch(new AutoLevelPitchToggle(autoLevelPitch));
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -21,6 +21,7 @@ namespace VRCCamera
         public ReactiveProperty<SmoothingStrength> SmoothingStrength { get; }
         public ReactiveProperty<PhotoRate> PhotoRate { get; }
         public ReactiveProperty<Duration> Duration { get; }
+        public ReactiveProperty<ShowUIInCameraToggle> ShowUIInCamera { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -42,6 +43,7 @@ namespace VRCCamera
             SmoothingStrength = new ReactiveProperty<SmoothingStrength>(new SmoothingStrength(Parameters.SmoothingStrength.DefaultValue));
             PhotoRate = new ReactiveProperty<PhotoRate>(new PhotoRate(Parameters.PhotoRate.DefaultValue));
             Duration = new ReactiveProperty<Duration>(new Duration(Parameters.Duration.DefaultValue));
+            ShowUIInCamera = new ReactiveProperty<ShowUIInCameraToggle>(new ShowUIInCameraToggle(false));
         }
 
         /// <summary>
@@ -136,6 +138,14 @@ namespace VRCCamera
         }
         
         /// <summary>
+        /// Sets ShowUIInCamera toggle value reactively
+        /// </summary>
+        public void SetShowUIInCamera(ShowUIInCameraToggle showUIInCamera)
+        {
+            ShowUIInCamera.SetValue(showUIInCamera);
+        }
+        
+        /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
         /// </summary>
         public void Dispose()
@@ -154,6 +164,7 @@ namespace VRCCamera
             SmoothingStrength?.ClearSubscriptions();
             PhotoRate?.ClearSubscriptions();
             Duration?.ClearSubscriptions();
+            ShowUIInCamera?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -24,6 +24,7 @@ namespace VRCCamera
         public ReactiveProperty<ShowUIInCameraToggle> ShowUIInCamera { get; }
         public ReactiveProperty<LockToggle> Lock { get; }
         public ReactiveProperty<LocalPlayerToggle> LocalPlayer { get; }
+        public ReactiveProperty<RemotePlayerToggle> RemotePlayer { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -48,6 +49,7 @@ namespace VRCCamera
             ShowUIInCamera = new ReactiveProperty<ShowUIInCameraToggle>(new ShowUIInCameraToggle(false));
             Lock = new ReactiveProperty<LockToggle>(new LockToggle(false));
             LocalPlayer = new ReactiveProperty<LocalPlayerToggle>(new LocalPlayerToggle(false));
+            RemotePlayer = new ReactiveProperty<RemotePlayerToggle>(new RemotePlayerToggle(false));
         }
 
         /// <summary>
@@ -164,6 +166,14 @@ namespace VRCCamera
         {
             LocalPlayer.SetValue(localPlayer);
         }
+
+        /// <summary>
+        /// Sets RemotePlayer toggle value reactively
+        /// </summary>
+        public void SetRemotePlayer(RemotePlayerToggle remotePlayer)
+        {
+            RemotePlayer.SetValue(remotePlayer);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -187,6 +197,7 @@ namespace VRCCamera
             ShowUIInCamera?.ClearSubscriptions();
             Lock?.ClearSubscriptions();
             LocalPlayer?.ClearSubscriptions();
+            RemotePlayer?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -22,6 +22,7 @@ namespace VRCCamera
         public ReactiveProperty<PhotoRate> PhotoRate { get; }
         public ReactiveProperty<Duration> Duration { get; }
         public ReactiveProperty<ShowUIInCameraToggle> ShowUIInCamera { get; }
+        public ReactiveProperty<LockToggle> Lock { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -44,6 +45,7 @@ namespace VRCCamera
             PhotoRate = new ReactiveProperty<PhotoRate>(new PhotoRate(Parameters.PhotoRate.DefaultValue));
             Duration = new ReactiveProperty<Duration>(new Duration(Parameters.Duration.DefaultValue));
             ShowUIInCamera = new ReactiveProperty<ShowUIInCameraToggle>(new ShowUIInCameraToggle(false));
+            Lock = new ReactiveProperty<LockToggle>(new LockToggle(false));
         }
 
         /// <summary>
@@ -136,13 +138,21 @@ namespace VRCCamera
         {
             Duration.SetValue(duration);
         }
-        
+
         /// <summary>
         /// Sets ShowUIInCamera toggle value reactively
         /// </summary>
         public void SetShowUIInCamera(ShowUIInCameraToggle showUIInCamera)
         {
             ShowUIInCamera.SetValue(showUIInCamera);
+        }
+
+        /// <summary>
+        /// Sets Lock toggle value reactively
+        /// </summary>
+        public void SetLock(LockToggle lockToggle)
+        {
+            Lock.SetValue(lockToggle);
         }
         
         /// <summary>
@@ -165,6 +175,7 @@ namespace VRCCamera
             PhotoRate?.ClearSubscriptions();
             Duration?.ClearSubscriptions();
             ShowUIInCamera?.ClearSubscriptions();
+            Lock?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -30,6 +30,7 @@ namespace VRCCamera
         public ReactiveProperty<SmoothMovementToggle> SmoothMovement { get; }
         public ReactiveProperty<LookAtMeToggle> LookAtMe { get; }
         public ReactiveProperty<AutoLevelRollToggle> AutoLevelRoll { get; }
+        public ReactiveProperty<AutoLevelPitchToggle> AutoLevelPitch { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -60,6 +61,7 @@ namespace VRCCamera
             SmoothMovement = new ReactiveProperty<SmoothMovementToggle>(new SmoothMovementToggle(false));
             LookAtMe = new ReactiveProperty<LookAtMeToggle>(new LookAtMeToggle(false));
             AutoLevelRoll = new ReactiveProperty<AutoLevelRollToggle>(new AutoLevelRollToggle(false));
+            AutoLevelPitch = new ReactiveProperty<AutoLevelPitchToggle>(new AutoLevelPitchToggle(false));
         }
 
         /// <summary>
@@ -224,6 +226,14 @@ namespace VRCCamera
         {
             AutoLevelRoll.SetValue(autoLevelRoll);
         }
+
+        /// <summary>
+        /// Sets AutoLevelPitch toggle value reactively
+        /// </summary>
+        public void SetAutoLevelPitch(AutoLevelPitchToggle autoLevelPitch)
+        {
+            AutoLevelPitch.SetValue(autoLevelPitch);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -253,6 +263,7 @@ namespace VRCCamera
             SmoothMovement?.ClearSubscriptions();
             LookAtMe?.ClearSubscriptions();
             AutoLevelRoll?.ClearSubscriptions();
+            AutoLevelPitch?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -25,6 +25,7 @@ namespace VRCCamera
         public ReactiveProperty<LockToggle> Lock { get; }
         public ReactiveProperty<LocalPlayerToggle> LocalPlayer { get; }
         public ReactiveProperty<RemotePlayerToggle> RemotePlayer { get; }
+        public ReactiveProperty<EnvironmentToggle> Environment { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -50,6 +51,7 @@ namespace VRCCamera
             Lock = new ReactiveProperty<LockToggle>(new LockToggle(false));
             LocalPlayer = new ReactiveProperty<LocalPlayerToggle>(new LocalPlayerToggle(false));
             RemotePlayer = new ReactiveProperty<RemotePlayerToggle>(new RemotePlayerToggle(false));
+            Environment = new ReactiveProperty<EnvironmentToggle>(new EnvironmentToggle(false));
         }
 
         /// <summary>
@@ -174,6 +176,14 @@ namespace VRCCamera
         {
             RemotePlayer.SetValue(remotePlayer);
         }
+
+        /// <summary>
+        /// Sets Environment toggle value reactively
+        /// </summary>
+        public void SetEnvironment(EnvironmentToggle environment)
+        {
+            Environment.SetValue(environment);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -198,6 +208,7 @@ namespace VRCCamera
             Lock?.ClearSubscriptions();
             LocalPlayer?.ClearSubscriptions();
             RemotePlayer?.ClearSubscriptions();
+            Environment?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -33,6 +33,7 @@ namespace VRCCamera
         public ReactiveProperty<AutoLevelPitchToggle> AutoLevelPitch { get; }
         public ReactiveProperty<FlyingToggle> Flying { get; }
         public ReactiveProperty<TriggerTakesPhotosToggle> TriggerTakesPhotos { get; }
+        public ReactiveProperty<DollyPathsStayVisibleToggle> DollyPathsStayVisible { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -66,6 +67,7 @@ namespace VRCCamera
             AutoLevelPitch = new ReactiveProperty<AutoLevelPitchToggle>(new AutoLevelPitchToggle(false));
             Flying = new ReactiveProperty<FlyingToggle>(new FlyingToggle(false));
             TriggerTakesPhotos = new ReactiveProperty<TriggerTakesPhotosToggle>(new TriggerTakesPhotosToggle(false));
+            DollyPathsStayVisible = new ReactiveProperty<DollyPathsStayVisibleToggle>(new DollyPathsStayVisibleToggle(false));
         }
 
         /// <summary>
@@ -254,6 +256,14 @@ namespace VRCCamera
         {
             TriggerTakesPhotos.SetValue(trigger);
         }
+
+        /// <summary>
+        /// Sets DollyPathsStayVisible toggle value reactively
+        /// </summary>
+        public void SetDollyPathsStayVisible(DollyPathsStayVisibleToggle dollyPathsStayVisible)
+        {
+            DollyPathsStayVisible.SetValue(dollyPathsStayVisible);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -286,6 +296,7 @@ namespace VRCCamera
             AutoLevelPitch?.ClearSubscriptions();
             Flying?.ClearSubscriptions();
             TriggerTakesPhotos?.ClearSubscriptions();
+            DollyPathsStayVisible?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -28,6 +28,7 @@ namespace VRCCamera
         public ReactiveProperty<EnvironmentToggle> Environment { get; }
         public ReactiveProperty<GreenScreenToggle> GreenScreen { get; }
         public ReactiveProperty<SmoothMovementToggle> SmoothMovement { get; }
+        public ReactiveProperty<LookAtMeToggle> LookAtMe { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -56,6 +57,7 @@ namespace VRCCamera
             Environment = new ReactiveProperty<EnvironmentToggle>(new EnvironmentToggle(false));
             GreenScreen = new ReactiveProperty<GreenScreenToggle>(new GreenScreenToggle(false));
             SmoothMovement = new ReactiveProperty<SmoothMovementToggle>(new SmoothMovementToggle(false));
+            LookAtMe = new ReactiveProperty<LookAtMeToggle>(new LookAtMeToggle(false));
         }
 
         /// <summary>
@@ -204,6 +206,14 @@ namespace VRCCamera
         {
             SmoothMovement.SetValue(smoothMovement);
         }
+
+        /// <summary>
+        /// Sets LookAtMe toggle value reactively
+        /// </summary>
+        public void SetLookAtMe(LookAtMeToggle lookAtMe)
+        {
+            LookAtMe.SetValue(lookAtMe);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -231,6 +241,7 @@ namespace VRCCamera
             Environment?.ClearSubscriptions();
             GreenScreen?.ClearSubscriptions();
             SmoothMovement?.ClearSubscriptions();
+            LookAtMe?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -36,6 +36,7 @@ namespace VRCCamera
         public ReactiveProperty<DollyPathsStayVisibleToggle> DollyPathsStayVisible { get; }
         public ReactiveProperty<CameraEarsToggle> CameraEars { get; }
         public ReactiveProperty<ShowFocusToggle> ShowFocus { get; }
+        public ReactiveProperty<StreamingToggle> Streaming { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -72,6 +73,7 @@ namespace VRCCamera
             DollyPathsStayVisible = new ReactiveProperty<DollyPathsStayVisibleToggle>(new DollyPathsStayVisibleToggle(false));
             CameraEars = new ReactiveProperty<CameraEarsToggle>(new CameraEarsToggle(false));
             ShowFocus = new ReactiveProperty<ShowFocusToggle>(new ShowFocusToggle(false));
+            Streaming = new ReactiveProperty<StreamingToggle>(new StreamingToggle(false));
         }
 
         /// <summary>
@@ -284,6 +286,14 @@ namespace VRCCamera
         {
             ShowFocus.SetValue(showFocus);
         }
+
+        /// <summary>
+        /// Sets Streaming toggle value reactively
+        /// </summary>
+        public void SetStreaming(StreamingToggle streaming)
+        {
+            Streaming.SetValue(streaming);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -319,6 +329,7 @@ namespace VRCCamera
             DollyPathsStayVisible?.ClearSubscriptions();
             CameraEars?.ClearSubscriptions();
             ShowFocus?.ClearSubscriptions();
+            Streaming?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -34,6 +34,7 @@ namespace VRCCamera
         public ReactiveProperty<FlyingToggle> Flying { get; }
         public ReactiveProperty<TriggerTakesPhotosToggle> TriggerTakesPhotos { get; }
         public ReactiveProperty<DollyPathsStayVisibleToggle> DollyPathsStayVisible { get; }
+        public ReactiveProperty<CameraEarsToggle> CameraEars { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -68,6 +69,7 @@ namespace VRCCamera
             Flying = new ReactiveProperty<FlyingToggle>(new FlyingToggle(false));
             TriggerTakesPhotos = new ReactiveProperty<TriggerTakesPhotosToggle>(new TriggerTakesPhotosToggle(false));
             DollyPathsStayVisible = new ReactiveProperty<DollyPathsStayVisibleToggle>(new DollyPathsStayVisibleToggle(false));
+            CameraEars = new ReactiveProperty<CameraEarsToggle>(new CameraEarsToggle(false));
         }
 
         /// <summary>
@@ -264,6 +266,14 @@ namespace VRCCamera
         {
             DollyPathsStayVisible.SetValue(dollyPathsStayVisible);
         }
+
+        /// <summary>
+        /// Sets CameraEars toggle value reactively
+        /// </summary>
+        public void SetCameraEars(CameraEarsToggle cameraEars)
+        {
+            CameraEars.SetValue(cameraEars);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -297,6 +307,7 @@ namespace VRCCamera
             Flying?.ClearSubscriptions();
             TriggerTakesPhotos?.ClearSubscriptions();
             DollyPathsStayVisible?.ClearSubscriptions();
+            CameraEars?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -23,6 +23,7 @@ namespace VRCCamera
         public ReactiveProperty<Duration> Duration { get; }
         public ReactiveProperty<ShowUIInCameraToggle> ShowUIInCamera { get; }
         public ReactiveProperty<LockToggle> Lock { get; }
+        public ReactiveProperty<LocalPlayerToggle> LocalPlayer { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -46,6 +47,7 @@ namespace VRCCamera
             Duration = new ReactiveProperty<Duration>(new Duration(Parameters.Duration.DefaultValue));
             ShowUIInCamera = new ReactiveProperty<ShowUIInCameraToggle>(new ShowUIInCameraToggle(false));
             Lock = new ReactiveProperty<LockToggle>(new LockToggle(false));
+            LocalPlayer = new ReactiveProperty<LocalPlayerToggle>(new LocalPlayerToggle(false));
         }
 
         /// <summary>
@@ -154,6 +156,14 @@ namespace VRCCamera
         {
             Lock.SetValue(lockToggle);
         }
+
+        /// <summary>
+        /// Sets LocalPlayer toggle value reactively
+        /// </summary>
+        public void SetLocalPlayer(LocalPlayerToggle localPlayer)
+        {
+            LocalPlayer.SetValue(localPlayer);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -176,6 +186,7 @@ namespace VRCCamera
             Duration?.ClearSubscriptions();
             ShowUIInCamera?.ClearSubscriptions();
             Lock?.ClearSubscriptions();
+            LocalPlayer?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -38,6 +38,7 @@ namespace VRCCamera
         public ReactiveProperty<ShowFocusToggle> ShowFocus { get; }
         public ReactiveProperty<StreamingToggle> Streaming { get; }
         public ReactiveProperty<RollWhileFlyingToggle> RollWhileFlying { get; }
+        public ReactiveProperty<OrientationIsLandscapeToggle> OrientationIsLandscape { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -76,6 +77,7 @@ namespace VRCCamera
             ShowFocus = new ReactiveProperty<ShowFocusToggle>(new ShowFocusToggle(false));
             Streaming = new ReactiveProperty<StreamingToggle>(new StreamingToggle(false));
             RollWhileFlying = new ReactiveProperty<RollWhileFlyingToggle>(new RollWhileFlyingToggle(false));
+            OrientationIsLandscape = new ReactiveProperty<OrientationIsLandscapeToggle>(new OrientationIsLandscapeToggle(false));
         }
 
         /// <summary>
@@ -304,6 +306,14 @@ namespace VRCCamera
         {
             RollWhileFlying.SetValue(rollWhileFlying);
         }
+
+        /// <summary>
+        /// Sets OrientationIsLandscape toggle value reactively
+        /// </summary>
+        public void SetOrientationIsLandscape(OrientationIsLandscapeToggle orientationIsLandscape)
+        {
+            OrientationIsLandscape.SetValue(orientationIsLandscape);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -341,6 +351,7 @@ namespace VRCCamera
             ShowFocus?.ClearSubscriptions();
             Streaming?.ClearSubscriptions();
             RollWhileFlying?.ClearSubscriptions();
+            OrientationIsLandscape?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -27,6 +27,7 @@ namespace VRCCamera
         public ReactiveProperty<RemotePlayerToggle> RemotePlayer { get; }
         public ReactiveProperty<EnvironmentToggle> Environment { get; }
         public ReactiveProperty<GreenScreenToggle> GreenScreen { get; }
+        public ReactiveProperty<SmoothMovementToggle> SmoothMovement { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -54,6 +55,7 @@ namespace VRCCamera
             RemotePlayer = new ReactiveProperty<RemotePlayerToggle>(new RemotePlayerToggle(false));
             Environment = new ReactiveProperty<EnvironmentToggle>(new EnvironmentToggle(false));
             GreenScreen = new ReactiveProperty<GreenScreenToggle>(new GreenScreenToggle(false));
+            SmoothMovement = new ReactiveProperty<SmoothMovementToggle>(new SmoothMovementToggle(false));
         }
 
         /// <summary>
@@ -194,6 +196,14 @@ namespace VRCCamera
         {
             GreenScreen.SetValue(greenScreen);
         }
+
+        /// <summary>
+        /// Sets SmoothMovement toggle value reactively
+        /// </summary>
+        public void SetSmoothMovement(SmoothMovementToggle smoothMovement)
+        {
+            SmoothMovement.SetValue(smoothMovement);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -220,6 +230,7 @@ namespace VRCCamera
             RemotePlayer?.ClearSubscriptions();
             Environment?.ClearSubscriptions();
             GreenScreen?.ClearSubscriptions();
+            SmoothMovement?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -29,6 +29,7 @@ namespace VRCCamera
         public ReactiveProperty<GreenScreenToggle> GreenScreen { get; }
         public ReactiveProperty<SmoothMovementToggle> SmoothMovement { get; }
         public ReactiveProperty<LookAtMeToggle> LookAtMe { get; }
+        public ReactiveProperty<AutoLevelRollToggle> AutoLevelRoll { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -58,6 +59,7 @@ namespace VRCCamera
             GreenScreen = new ReactiveProperty<GreenScreenToggle>(new GreenScreenToggle(false));
             SmoothMovement = new ReactiveProperty<SmoothMovementToggle>(new SmoothMovementToggle(false));
             LookAtMe = new ReactiveProperty<LookAtMeToggle>(new LookAtMeToggle(false));
+            AutoLevelRoll = new ReactiveProperty<AutoLevelRollToggle>(new AutoLevelRollToggle(false));
         }
 
         /// <summary>
@@ -214,6 +216,14 @@ namespace VRCCamera
         {
             LookAtMe.SetValue(lookAtMe);
         }
+
+        /// <summary>
+        /// Sets AutoLevelRoll toggle value reactively
+        /// </summary>
+        public void SetAutoLevelRoll(AutoLevelRollToggle autoLevelRoll)
+        {
+            AutoLevelRoll.SetValue(autoLevelRoll);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -242,6 +252,7 @@ namespace VRCCamera
             GreenScreen?.ClearSubscriptions();
             SmoothMovement?.ClearSubscriptions();
             LookAtMe?.ClearSubscriptions();
+            AutoLevelRoll?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -35,6 +35,7 @@ namespace VRCCamera
         public ReactiveProperty<TriggerTakesPhotosToggle> TriggerTakesPhotos { get; }
         public ReactiveProperty<DollyPathsStayVisibleToggle> DollyPathsStayVisible { get; }
         public ReactiveProperty<CameraEarsToggle> CameraEars { get; }
+        public ReactiveProperty<ShowFocusToggle> ShowFocus { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -70,6 +71,7 @@ namespace VRCCamera
             TriggerTakesPhotos = new ReactiveProperty<TriggerTakesPhotosToggle>(new TriggerTakesPhotosToggle(false));
             DollyPathsStayVisible = new ReactiveProperty<DollyPathsStayVisibleToggle>(new DollyPathsStayVisibleToggle(false));
             CameraEars = new ReactiveProperty<CameraEarsToggle>(new CameraEarsToggle(false));
+            ShowFocus = new ReactiveProperty<ShowFocusToggle>(new ShowFocusToggle(false));
         }
 
         /// <summary>
@@ -274,6 +276,14 @@ namespace VRCCamera
         {
             CameraEars.SetValue(cameraEars);
         }
+
+        /// <summary>
+        /// Sets ShowFocus toggle value reactively
+        /// </summary>
+        public void SetShowFocus(ShowFocusToggle showFocus)
+        {
+            ShowFocus.SetValue(showFocus);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -308,6 +318,7 @@ namespace VRCCamera
             TriggerTakesPhotos?.ClearSubscriptions();
             DollyPathsStayVisible?.ClearSubscriptions();
             CameraEars?.ClearSubscriptions();
+            ShowFocus?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -26,6 +26,7 @@ namespace VRCCamera
         public ReactiveProperty<LocalPlayerToggle> LocalPlayer { get; }
         public ReactiveProperty<RemotePlayerToggle> RemotePlayer { get; }
         public ReactiveProperty<EnvironmentToggle> Environment { get; }
+        public ReactiveProperty<GreenScreenToggle> GreenScreen { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -52,6 +53,7 @@ namespace VRCCamera
             LocalPlayer = new ReactiveProperty<LocalPlayerToggle>(new LocalPlayerToggle(false));
             RemotePlayer = new ReactiveProperty<RemotePlayerToggle>(new RemotePlayerToggle(false));
             Environment = new ReactiveProperty<EnvironmentToggle>(new EnvironmentToggle(false));
+            GreenScreen = new ReactiveProperty<GreenScreenToggle>(new GreenScreenToggle(false));
         }
 
         /// <summary>
@@ -184,6 +186,14 @@ namespace VRCCamera
         {
             Environment.SetValue(environment);
         }
+
+        /// <summary>
+        /// Sets GreenScreen toggle value reactively
+        /// </summary>
+        public void SetGreenScreen(GreenScreenToggle greenScreen)
+        {
+            GreenScreen.SetValue(greenScreen);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -209,6 +219,7 @@ namespace VRCCamera
             LocalPlayer?.ClearSubscriptions();
             RemotePlayer?.ClearSubscriptions();
             Environment?.ClearSubscriptions();
+            GreenScreen?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -31,6 +31,7 @@ namespace VRCCamera
         public ReactiveProperty<LookAtMeToggle> LookAtMe { get; }
         public ReactiveProperty<AutoLevelRollToggle> AutoLevelRoll { get; }
         public ReactiveProperty<AutoLevelPitchToggle> AutoLevelPitch { get; }
+        public ReactiveProperty<FlyingToggle> Flying { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -62,6 +63,7 @@ namespace VRCCamera
             LookAtMe = new ReactiveProperty<LookAtMeToggle>(new LookAtMeToggle(false));
             AutoLevelRoll = new ReactiveProperty<AutoLevelRollToggle>(new AutoLevelRollToggle(false));
             AutoLevelPitch = new ReactiveProperty<AutoLevelPitchToggle>(new AutoLevelPitchToggle(false));
+            Flying = new ReactiveProperty<FlyingToggle>(new FlyingToggle(false));
         }
 
         /// <summary>
@@ -234,6 +236,14 @@ namespace VRCCamera
         {
             AutoLevelPitch.SetValue(autoLevelPitch);
         }
+
+        /// <summary>
+        /// Sets Flying toggle value reactively
+        /// </summary>
+        public void SetFlying(FlyingToggle flying)
+        {
+            Flying.SetValue(flying);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -264,6 +274,7 @@ namespace VRCCamera
             LookAtMe?.ClearSubscriptions();
             AutoLevelRoll?.ClearSubscriptions();
             AutoLevelPitch?.ClearSubscriptions();
+            Flying?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -32,6 +32,7 @@ namespace VRCCamera
         public ReactiveProperty<AutoLevelRollToggle> AutoLevelRoll { get; }
         public ReactiveProperty<AutoLevelPitchToggle> AutoLevelPitch { get; }
         public ReactiveProperty<FlyingToggle> Flying { get; }
+        public ReactiveProperty<TriggerTakesPhotosToggle> TriggerTakesPhotos { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -64,6 +65,7 @@ namespace VRCCamera
             AutoLevelRoll = new ReactiveProperty<AutoLevelRollToggle>(new AutoLevelRollToggle(false));
             AutoLevelPitch = new ReactiveProperty<AutoLevelPitchToggle>(new AutoLevelPitchToggle(false));
             Flying = new ReactiveProperty<FlyingToggle>(new FlyingToggle(false));
+            TriggerTakesPhotos = new ReactiveProperty<TriggerTakesPhotosToggle>(new TriggerTakesPhotosToggle(false));
         }
 
         /// <summary>
@@ -244,6 +246,14 @@ namespace VRCCamera
         {
             Flying.SetValue(flying);
         }
+
+        /// <summary>
+        /// Sets TriggerTakesPhotos toggle value reactively
+        /// </summary>
+        public void SetTriggerTakesPhotos(TriggerTakesPhotosToggle trigger)
+        {
+            TriggerTakesPhotos.SetValue(trigger);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -275,6 +285,7 @@ namespace VRCCamera
             AutoLevelRoll?.ClearSubscriptions();
             AutoLevelPitch?.ClearSubscriptions();
             Flying?.ClearSubscriptions();
+            TriggerTakesPhotos?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -37,6 +37,7 @@ namespace VRCCamera
         public ReactiveProperty<CameraEarsToggle> CameraEars { get; }
         public ReactiveProperty<ShowFocusToggle> ShowFocus { get; }
         public ReactiveProperty<StreamingToggle> Streaming { get; }
+        public ReactiveProperty<RollWhileFlyingToggle> RollWhileFlying { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -74,6 +75,7 @@ namespace VRCCamera
             CameraEars = new ReactiveProperty<CameraEarsToggle>(new CameraEarsToggle(false));
             ShowFocus = new ReactiveProperty<ShowFocusToggle>(new ShowFocusToggle(false));
             Streaming = new ReactiveProperty<StreamingToggle>(new StreamingToggle(false));
+            RollWhileFlying = new ReactiveProperty<RollWhileFlyingToggle>(new RollWhileFlyingToggle(false));
         }
 
         /// <summary>
@@ -294,6 +296,14 @@ namespace VRCCamera
         {
             Streaming.SetValue(streaming);
         }
+
+        /// <summary>
+        /// Sets RollWhileFlying toggle value reactively
+        /// </summary>
+        public void SetRollWhileFlying(RollWhileFlyingToggle rollWhileFlying)
+        {
+            RollWhileFlying.SetValue(rollWhileFlying);
+        }
         
         /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
@@ -330,6 +340,7 @@ namespace VRCCamera
             CameraEars?.ClearSubscriptions();
             ShowFocus?.ClearSubscriptions();
             Streaming?.ClearSubscriptions();
+            RollWhileFlying?.ClearSubscriptions();
         }
     }
 }

--- a/Scripts/Runtime/OSC/AutoLevelPitchToggleConverter.cs
+++ b/Scripts/Runtime/OSC/AutoLevelPitchToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class AutoLevelPitchToggleConverter : IOSCMessageConverter<AutoLevelPitchToggle>
+    {
+        public AutoLevelPitchToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.AutoLevelPitch)
+            {
+                return new AutoLevelPitchToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new AutoLevelPitchToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new AutoLevelPitchToggle(value);
+        }
+
+        public Message ToOSCMessage(AutoLevelPitchToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/AutoLevelPitchToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/AutoLevelPitchToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 260a23f44faad9c49aeb2db28833db44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/AutoLevelRollToggleConverter.cs
+++ b/Scripts/Runtime/OSC/AutoLevelRollToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class AutoLevelRollToggleConverter : IOSCMessageConverter<AutoLevelRollToggle>
+    {
+        public AutoLevelRollToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.AutoLevelRoll)
+            {
+                return new AutoLevelRollToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new AutoLevelRollToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new AutoLevelRollToggle(value);
+        }
+
+        public Message ToOSCMessage(AutoLevelRollToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/AutoLevelRollToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/AutoLevelRollToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02333eca120a1d14a8b3e6b3235f3d6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/CameraEarsToggleConverter.cs
+++ b/Scripts/Runtime/OSC/CameraEarsToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class CameraEarsToggleConverter : IOSCMessageConverter<CameraEarsToggle>
+    {
+        public CameraEarsToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.CameraEars)
+            {
+                return new CameraEarsToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new CameraEarsToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new CameraEarsToggle(value);
+        }
+
+        public Message ToOSCMessage(CameraEarsToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/CameraEarsToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/CameraEarsToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2113219c622889d46a443fef27932057
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/DollyPathsStayVisibleToggleConverter.cs
+++ b/Scripts/Runtime/OSC/DollyPathsStayVisibleToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class DollyPathsStayVisibleToggleConverter : IOSCMessageConverter<DollyPathsStayVisibleToggle>
+    {
+        public DollyPathsStayVisibleToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.DollyPathsStayVisible)
+            {
+                return new DollyPathsStayVisibleToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new DollyPathsStayVisibleToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new DollyPathsStayVisibleToggle(value);
+        }
+
+        public Message ToOSCMessage(DollyPathsStayVisibleToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/DollyPathsStayVisibleToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/DollyPathsStayVisibleToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 921967e63735cc54c84a3d7df2159c0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/EnvironmentToggleConverter.cs
+++ b/Scripts/Runtime/OSC/EnvironmentToggleConverter.cs
@@ -1,0 +1,39 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class EnvironmentToggleConverter : IOSCMessageConverter<EnvironmentToggle>
+    {
+        public EnvironmentToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.Environment)
+            {
+                return new EnvironmentToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new EnvironmentToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new EnvironmentToggle(value);
+        }
+
+        public Message ToOSCMessage(EnvironmentToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.Environment, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/EnvironmentToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/EnvironmentToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4747ff679a1b08d4f83762e47483ba43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/FlyingToggleConverter.cs
+++ b/Scripts/Runtime/OSC/FlyingToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class FlyingToggleConverter : IOSCMessageConverter<FlyingToggle>
+    {
+        public FlyingToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.Flying)
+            {
+                return new FlyingToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new FlyingToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new FlyingToggle(value);
+        }
+
+        public Message ToOSCMessage(FlyingToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.Flying, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/FlyingToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/FlyingToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d500cf216872b042804b4110d874d6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/GreenScreenToggleConverter.cs
+++ b/Scripts/Runtime/OSC/GreenScreenToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class GreenScreenToggleConverter : IOSCMessageConverter<GreenScreenToggle>
+    {
+        public GreenScreenToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.GreenScreen)
+            {
+                return new GreenScreenToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new GreenScreenToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new GreenScreenToggle(value);
+        }
+
+        public Message ToOSCMessage(GreenScreenToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/GreenScreenToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/GreenScreenToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e7381baa017d7142984ed1a71f696cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/LocalPlayerToggleConverter.cs
+++ b/Scripts/Runtime/OSC/LocalPlayerToggleConverter.cs
@@ -1,0 +1,39 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class LocalPlayerToggleConverter : IOSCMessageConverter<LocalPlayerToggle>
+    {
+        public LocalPlayerToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.LocalPlayer)
+            {
+                return new LocalPlayerToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new LocalPlayerToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new LocalPlayerToggle(value);
+        }
+
+        public Message ToOSCMessage(LocalPlayerToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/LocalPlayerToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/LocalPlayerToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19aac2c52968c8c478826a07a698240c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/LockToggleConverter.cs
+++ b/Scripts/Runtime/OSC/LockToggleConverter.cs
@@ -1,0 +1,42 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class LockToggleConverter : IOSCMessageConverter<LockToggle>
+    {
+        public LockToggle FromOSCMessage(Message message)
+        {
+            // Validate OSC address
+            if (message.Address != OSCCameraEndpoints.Lock)
+            {
+                return new LockToggle(false);
+            }
+
+            // Validate arguments exist and count
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new LockToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+
+            // Handle Bool, Int32, and Float32
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new LockToggle(value);
+        }
+
+        public Message ToOSCMessage(LockToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.Lock, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/LockToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/LockToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0aa5dce21036f14da08a7684c3ab4be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/LookAtMeToggleConverter.cs
+++ b/Scripts/Runtime/OSC/LookAtMeToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class LookAtMeToggleConverter : IOSCMessageConverter<LookAtMeToggle>
+    {
+        public LookAtMeToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.LookAtMe)
+            {
+                return new LookAtMeToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new LookAtMeToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new LookAtMeToggle(value);
+        }
+
+        public Message ToOSCMessage(LookAtMeToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/LookAtMeToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/LookAtMeToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd5d917fd3e3eff48a2b241521592bff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/OrientationIsLandscapeToggleConverter.cs
+++ b/Scripts/Runtime/OSC/OrientationIsLandscapeToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class OrientationIsLandscapeToggleConverter : IOSCMessageConverter<OrientationIsLandscapeToggle>
+    {
+        public OrientationIsLandscapeToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.OrientationIsLandscape)
+            {
+                return new OrientationIsLandscapeToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new OrientationIsLandscapeToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new OrientationIsLandscapeToggle(value);
+        }
+
+        public Message ToOSCMessage(OrientationIsLandscapeToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/OrientationIsLandscapeToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/OrientationIsLandscapeToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8dee448a0836cf941b9d9a5ee175badd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/RemotePlayerToggleConverter.cs
+++ b/Scripts/Runtime/OSC/RemotePlayerToggleConverter.cs
@@ -1,0 +1,39 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class RemotePlayerToggleConverter : IOSCMessageConverter<RemotePlayerToggle>
+    {
+        public RemotePlayerToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.RemotePlayer)
+            {
+                return new RemotePlayerToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new RemotePlayerToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new RemotePlayerToggle(value);
+        }
+
+        public Message ToOSCMessage(RemotePlayerToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/RemotePlayerToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/RemotePlayerToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d682f27fc0d15df4fa3e5d7892d359e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/RollWhileFlyingToggleConverter.cs
+++ b/Scripts/Runtime/OSC/RollWhileFlyingToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class RollWhileFlyingToggleConverter : IOSCMessageConverter<RollWhileFlyingToggle>
+    {
+        public RollWhileFlyingToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.RollWhileFlying)
+            {
+                return new RollWhileFlyingToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new RollWhileFlyingToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new RollWhileFlyingToggle(value);
+        }
+
+        public Message ToOSCMessage(RollWhileFlyingToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/RollWhileFlyingToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/RollWhileFlyingToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41510435d83ccee4e8ae76ccd0b2ff03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/ShowFocusToggleConverter.cs
+++ b/Scripts/Runtime/OSC/ShowFocusToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class ShowFocusToggleConverter : IOSCMessageConverter<ShowFocusToggle>
+    {
+        public ShowFocusToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.ShowFocus)
+            {
+                return new ShowFocusToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new ShowFocusToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new ShowFocusToggle(value);
+        }
+
+        public Message ToOSCMessage(ShowFocusToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/ShowFocusToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/ShowFocusToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2861535970d589546a2433a9581ae708
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/ShowUIInCameraToggleConverter.cs
+++ b/Scripts/Runtime/OSC/ShowUIInCameraToggleConverter.cs
@@ -1,0 +1,41 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class ShowUIInCameraToggleConverter : IOSCMessageConverter<ShowUIInCameraToggle>
+    {
+        public ShowUIInCameraToggle FromOSCMessage(Message message)
+        {
+            // Validate OSC address
+            if (message.Address != OSCCameraEndpoints.ShowUIInCamera)
+            {
+                return new ShowUIInCameraToggle(false);
+            }
+            
+            // Validate arguments exist and count
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new ShowUIInCameraToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            
+            // Handle both Bool and Int32 types (VRChat may send either)
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+            
+            return new ShowUIInCameraToggle(value);
+        }
+
+        public Message ToOSCMessage(ShowUIInCameraToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.ShowUIInCamera, new[] { new Argument(toggle.Value) });
+        }
+    }
+}

--- a/Scripts/Runtime/OSC/ShowUIInCameraToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/ShowUIInCameraToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0559c541fc4da745b3767536a3d1b45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/SmoothMovementToggleConverter.cs
+++ b/Scripts/Runtime/OSC/SmoothMovementToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class SmoothMovementToggleConverter : IOSCMessageConverter<SmoothMovementToggle>
+    {
+        public SmoothMovementToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.SmoothMovement)
+            {
+                return new SmoothMovementToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new SmoothMovementToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new SmoothMovementToggle(value);
+        }
+
+        public Message ToOSCMessage(SmoothMovementToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/SmoothMovementToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/SmoothMovementToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a69abd44b313334580b27992466c954
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/StreamingToggleConverter.cs
+++ b/Scripts/Runtime/OSC/StreamingToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class StreamingToggleConverter : IOSCMessageConverter<StreamingToggle>
+    {
+        public StreamingToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.Streaming)
+            {
+                return new StreamingToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new StreamingToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new StreamingToggle(value);
+        }
+
+        public Message ToOSCMessage(StreamingToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.Streaming, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/StreamingToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/StreamingToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb6e5bcba9d4b0c48896de50a6e0a6eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/TriggerTakesPhotosToggleConverter.cs
+++ b/Scripts/Runtime/OSC/TriggerTakesPhotosToggleConverter.cs
@@ -1,0 +1,38 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class TriggerTakesPhotosToggleConverter : IOSCMessageConverter<TriggerTakesPhotosToggle>
+    {
+        public TriggerTakesPhotosToggle FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.TriggerTakesPhotos)
+            {
+                return new TriggerTakesPhotosToggle(false);
+            }
+
+            if (message.Arguments is not { Length: > 0 })
+            {
+                return new TriggerTakesPhotosToggle(false);
+            }
+
+            var arg = message.Arguments[0];
+            bool value = arg.Type switch
+            {
+                Argument.ValueType.Bool => arg.AsBool(),
+                Argument.ValueType.Int32 => arg.AsInt32() != 0,
+                Argument.ValueType.Float32 => arg.AsFloat32() != 0f,
+                _ => false
+            };
+
+            return new TriggerTakesPhotosToggle(value);
+        }
+
+        public Message ToOSCMessage(TriggerTakesPhotosToggle toggle)
+        {
+            return new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument(toggle.Value) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/TriggerTakesPhotosToggleConverter.cs.meta
+++ b/Scripts/Runtime/OSC/TriggerTakesPhotosToggleConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 837bbab1122af3f4b8b0bb299a3eb95c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -30,6 +30,7 @@ namespace VRCCamera
         private readonly SmoothMovementToggleConverter _smoothMovementToggleConverter = new();
         private readonly LookAtMeToggleConverter _lookAtMeToggleConverter = new();
         private readonly AutoLevelRollToggleConverter _autoLevelRollToggleConverter = new();
+        private readonly AutoLevelPitchToggleConverter _autoLevelPitchToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -60,6 +61,7 @@ namespace VRCCamera
             _vrcCamera.SmoothMovement.OnValueChanged += OnSmoothMovementChanged;
             _vrcCamera.LookAtMe.OnValueChanged += OnLookAtMeChanged;
             _vrcCamera.AutoLevelRoll.OnValueChanged += OnAutoLevelRollChanged;
+            _vrcCamera.AutoLevelPitch.OnValueChanged += OnAutoLevelPitchChanged;
             
             // Send initial values
             Sync();
@@ -246,6 +248,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnAutoLevelPitchChanged(AutoLevelPitchToggle autoLevelPitch)
+        {
+            if (_disposed) return;
+
+            var message = _autoLevelPitchToggleConverter.ToOSCMessage(autoLevelPitch);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -278,6 +288,7 @@ namespace VRCCamera
             _transmitter.Send(_smoothMovementToggleConverter.ToOSCMessage(_vrcCamera.SmoothMovement.Value));
             _transmitter.Send(_lookAtMeToggleConverter.ToOSCMessage(_vrcCamera.LookAtMe.Value));
             _transmitter.Send(_autoLevelRollToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelRoll.Value));
+            _transmitter.Send(_autoLevelPitchToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelPitch.Value));
         }
 
         public void Dispose()
@@ -309,6 +320,7 @@ namespace VRCCamera
                 _vrcCamera.SmoothMovement.OnValueChanged -= OnSmoothMovementChanged;
                 _vrcCamera.LookAtMe.OnValueChanged -= OnLookAtMeChanged;
                 _vrcCamera.AutoLevelRoll.OnValueChanged -= OnAutoLevelRollChanged;
+                _vrcCamera.AutoLevelPitch.OnValueChanged -= OnAutoLevelPitchChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -382,7 +382,8 @@ namespace VRCCamera
         public void Dispose()
         {
             if (_disposed) return;
-            
+            _disposed = true; // Gate all handlers before tearing down
+
             // Unsubscribe from events
             if (_vrcCamera != null)
             {
@@ -418,9 +419,8 @@ namespace VRCCamera
                 _vrcCamera.RollWhileFlying.OnValueChanged -= OnRollWhileFlyingChanged;
                 _vrcCamera.OrientationIsLandscape.OnValueChanged -= OnOrientationIsLandscapeChanged;
             }
-            
+
             _transmitter?.Dispose();
-            _disposed = true;
         }
     }
 }

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -25,6 +25,7 @@ namespace VRCCamera
         private readonly LockToggleConverter _lockToggleConverter = new();
         private readonly LocalPlayerToggleConverter _localPlayerToggleConverter = new();
         private readonly RemotePlayerToggleConverter _remotePlayerToggleConverter = new();
+        private readonly EnvironmentToggleConverter _environmentToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -50,6 +51,7 @@ namespace VRCCamera
             _vrcCamera.Lock.OnValueChanged += OnLockChanged;
             _vrcCamera.LocalPlayer.OnValueChanged += OnLocalPlayerChanged;
             _vrcCamera.RemotePlayer.OnValueChanged += OnRemotePlayerChanged;
+            _vrcCamera.Environment.OnValueChanged += OnEnvironmentChanged;
             
             // Send initial values
             Sync();
@@ -196,6 +198,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnEnvironmentChanged(EnvironmentToggle environment)
+        {
+            if (_disposed) return;
+
+            var message = _environmentToggleConverter.ToOSCMessage(environment);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -223,6 +233,7 @@ namespace VRCCamera
             _transmitter.Send(_lockToggleConverter.ToOSCMessage(_vrcCamera.Lock.Value));
             _transmitter.Send(_localPlayerToggleConverter.ToOSCMessage(_vrcCamera.LocalPlayer.Value));
             _transmitter.Send(_remotePlayerToggleConverter.ToOSCMessage(_vrcCamera.RemotePlayer.Value));
+            _transmitter.Send(_environmentToggleConverter.ToOSCMessage(_vrcCamera.Environment.Value));
         }
 
         public void Dispose()
@@ -249,6 +260,7 @@ namespace VRCCamera
                 _vrcCamera.Lock.OnValueChanged -= OnLockChanged;
                 _vrcCamera.LocalPlayer.OnValueChanged -= OnLocalPlayerChanged;
                 _vrcCamera.RemotePlayer.OnValueChanged -= OnRemotePlayerChanged;
+                _vrcCamera.Environment.OnValueChanged -= OnEnvironmentChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -33,6 +33,7 @@ namespace VRCCamera
         private readonly AutoLevelPitchToggleConverter _autoLevelPitchToggleConverter = new();
         private readonly FlyingToggleConverter _flyingToggleConverter = new();
         private readonly TriggerTakesPhotosToggleConverter _triggerTakesPhotosToggleConverter = new();
+        private readonly DollyPathsStayVisibleToggleConverter _dollyPathsStayVisibleToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -66,6 +67,7 @@ namespace VRCCamera
             _vrcCamera.AutoLevelPitch.OnValueChanged += OnAutoLevelPitchChanged;
             _vrcCamera.Flying.OnValueChanged += OnFlyingChanged;
             _vrcCamera.TriggerTakesPhotos.OnValueChanged += OnTriggerTakesPhotosChanged;
+            _vrcCamera.DollyPathsStayVisible.OnValueChanged += OnDollyPathsStayVisibleChanged;
             
             // Send initial values
             Sync();
@@ -276,6 +278,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnDollyPathsStayVisibleChanged(DollyPathsStayVisibleToggle dolly)
+        {
+            if (_disposed) return;
+
+            var message = _dollyPathsStayVisibleToggleConverter.ToOSCMessage(dolly);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -311,6 +321,7 @@ namespace VRCCamera
             _transmitter.Send(_autoLevelPitchToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelPitch.Value));
             _transmitter.Send(_flyingToggleConverter.ToOSCMessage(_vrcCamera.Flying.Value));
             _transmitter.Send(_triggerTakesPhotosToggleConverter.ToOSCMessage(_vrcCamera.TriggerTakesPhotos.Value));
+            _transmitter.Send(_dollyPathsStayVisibleToggleConverter.ToOSCMessage(_vrcCamera.DollyPathsStayVisible.Value));
         }
 
         public void Dispose()
@@ -345,6 +356,7 @@ namespace VRCCamera
                 _vrcCamera.AutoLevelPitch.OnValueChanged -= OnAutoLevelPitchChanged;
                 _vrcCamera.Flying.OnValueChanged -= OnFlyingChanged;
                 _vrcCamera.TriggerTakesPhotos.OnValueChanged -= OnTriggerTakesPhotosChanged;
+                _vrcCamera.DollyPathsStayVisible.OnValueChanged -= OnDollyPathsStayVisibleChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -37,6 +37,7 @@ namespace VRCCamera
         private readonly CameraEarsToggleConverter _cameraEarsToggleConverter = new();
         private readonly ShowFocusToggleConverter _showFocusToggleConverter = new();
         private readonly StreamingToggleConverter _streamingToggleConverter = new();
+        private readonly RollWhileFlyingToggleConverter _rollWhileFlyingToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -74,6 +75,7 @@ namespace VRCCamera
             _vrcCamera.CameraEars.OnValueChanged += OnCameraEarsChanged;
             _vrcCamera.ShowFocus.OnValueChanged += OnShowFocusChanged;
             _vrcCamera.Streaming.OnValueChanged += OnStreamingChanged;
+            _vrcCamera.RollWhileFlying.OnValueChanged += OnRollWhileFlyingChanged;
             
             // Send initial values
             Sync();
@@ -316,6 +318,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnRollWhileFlyingChanged(RollWhileFlyingToggle rollWhileFlying)
+        {
+            if (_disposed) return;
+
+            var message = _rollWhileFlyingToggleConverter.ToOSCMessage(rollWhileFlying);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -355,6 +365,7 @@ namespace VRCCamera
             _transmitter.Send(_cameraEarsToggleConverter.ToOSCMessage(_vrcCamera.CameraEars.Value));
             _transmitter.Send(_showFocusToggleConverter.ToOSCMessage(_vrcCamera.ShowFocus.Value));
             _transmitter.Send(_streamingToggleConverter.ToOSCMessage(_vrcCamera.Streaming.Value));
+            _transmitter.Send(_rollWhileFlyingToggleConverter.ToOSCMessage(_vrcCamera.RollWhileFlying.Value));
         }
 
         public void Dispose()
@@ -393,6 +404,7 @@ namespace VRCCamera
                 _vrcCamera.CameraEars.OnValueChanged -= OnCameraEarsChanged;
                 _vrcCamera.ShowFocus.OnValueChanged -= OnShowFocusChanged;
                 _vrcCamera.Streaming.OnValueChanged -= OnStreamingChanged;
+                _vrcCamera.RollWhileFlying.OnValueChanged -= OnRollWhileFlyingChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -38,6 +38,7 @@ namespace VRCCamera
         private readonly ShowFocusToggleConverter _showFocusToggleConverter = new();
         private readonly StreamingToggleConverter _streamingToggleConverter = new();
         private readonly RollWhileFlyingToggleConverter _rollWhileFlyingToggleConverter = new();
+        private readonly OrientationIsLandscapeToggleConverter _orientationIsLandscapeToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -76,6 +77,7 @@ namespace VRCCamera
             _vrcCamera.ShowFocus.OnValueChanged += OnShowFocusChanged;
             _vrcCamera.Streaming.OnValueChanged += OnStreamingChanged;
             _vrcCamera.RollWhileFlying.OnValueChanged += OnRollWhileFlyingChanged;
+            _vrcCamera.OrientationIsLandscape.OnValueChanged += OnOrientationIsLandscapeChanged;
             
             // Send initial values
             Sync();
@@ -326,6 +328,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnOrientationIsLandscapeChanged(OrientationIsLandscapeToggle orientation)
+        {
+            if (_disposed) return;
+
+            var message = _orientationIsLandscapeToggleConverter.ToOSCMessage(orientation);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -366,6 +376,7 @@ namespace VRCCamera
             _transmitter.Send(_showFocusToggleConverter.ToOSCMessage(_vrcCamera.ShowFocus.Value));
             _transmitter.Send(_streamingToggleConverter.ToOSCMessage(_vrcCamera.Streaming.Value));
             _transmitter.Send(_rollWhileFlyingToggleConverter.ToOSCMessage(_vrcCamera.RollWhileFlying.Value));
+            _transmitter.Send(_orientationIsLandscapeToggleConverter.ToOSCMessage(_vrcCamera.OrientationIsLandscape.Value));
         }
 
         public void Dispose()
@@ -405,6 +416,7 @@ namespace VRCCamera
                 _vrcCamera.ShowFocus.OnValueChanged -= OnShowFocusChanged;
                 _vrcCamera.Streaming.OnValueChanged -= OnStreamingChanged;
                 _vrcCamera.RollWhileFlying.OnValueChanged -= OnRollWhileFlyingChanged;
+                _vrcCamera.OrientationIsLandscape.OnValueChanged -= OnOrientationIsLandscapeChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -21,6 +21,7 @@ namespace VRCCamera
         private readonly SmoothingStrengthConverter _smoothingStrengthConverter = new();
         private readonly PhotoRateConverter _photoRateConverter = new();
         private readonly DurationConverter _durationConverter = new();
+        private readonly ShowUIInCameraToggleConverter _showUIInCameraToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -42,6 +43,7 @@ namespace VRCCamera
             _vrcCamera.SmoothingStrength.OnValueChanged += OnSmoothingStrengthChanged;
             _vrcCamera.PhotoRate.OnValueChanged += OnPhotoRateChanged;
             _vrcCamera.Duration.OnValueChanged += OnDurationChanged;
+            _vrcCamera.ShowUIInCamera.OnValueChanged += OnShowUIInCameraChanged;
             
             // Send initial values
             Sync();
@@ -155,6 +157,14 @@ namespace VRCCamera
             var message = _durationConverter.ToOSCMessage(duration);
             _transmitter.Send(message);
         }
+        
+        private void OnShowUIInCameraChanged(ShowUIInCameraToggle showUIInCamera)
+        {
+            if (_disposed) return;
+            
+            var message = _showUIInCameraToggleConverter.ToOSCMessage(showUIInCamera);
+            _transmitter.Send(message);
+        }
 
         public void Sync()
         {
@@ -179,6 +189,7 @@ namespace VRCCamera
             _transmitter.Send(_smoothingStrengthConverter.ToOSCMessage(_vrcCamera.SmoothingStrength.Value));
             _transmitter.Send(_photoRateConverter.ToOSCMessage(_vrcCamera.PhotoRate.Value));
             _transmitter.Send(_durationConverter.ToOSCMessage(_vrcCamera.Duration.Value));
+            _transmitter.Send(_showUIInCameraToggleConverter.ToOSCMessage(_vrcCamera.ShowUIInCamera.Value));
         }
 
         public void Dispose()
@@ -201,6 +212,7 @@ namespace VRCCamera
                 _vrcCamera.SmoothingStrength.OnValueChanged -= OnSmoothingStrengthChanged;
                 _vrcCamera.PhotoRate.OnValueChanged -= OnPhotoRateChanged;
                 _vrcCamera.Duration.OnValueChanged -= OnDurationChanged;
+                _vrcCamera.ShowUIInCamera.OnValueChanged -= OnShowUIInCameraChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -23,6 +23,7 @@ namespace VRCCamera
         private readonly DurationConverter _durationConverter = new();
         private readonly ShowUIInCameraToggleConverter _showUIInCameraToggleConverter = new();
         private readonly LockToggleConverter _lockToggleConverter = new();
+        private readonly LocalPlayerToggleConverter _localPlayerToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -46,6 +47,7 @@ namespace VRCCamera
             _vrcCamera.Duration.OnValueChanged += OnDurationChanged;
             _vrcCamera.ShowUIInCamera.OnValueChanged += OnShowUIInCameraChanged;
             _vrcCamera.Lock.OnValueChanged += OnLockChanged;
+            _vrcCamera.LocalPlayer.OnValueChanged += OnLocalPlayerChanged;
             
             // Send initial values
             Sync();
@@ -176,6 +178,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnLocalPlayerChanged(LocalPlayerToggle localPlayer)
+        {
+            if (_disposed) return;
+
+            var message = _localPlayerToggleConverter.ToOSCMessage(localPlayer);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -201,6 +211,7 @@ namespace VRCCamera
             _transmitter.Send(_durationConverter.ToOSCMessage(_vrcCamera.Duration.Value));
             _transmitter.Send(_showUIInCameraToggleConverter.ToOSCMessage(_vrcCamera.ShowUIInCamera.Value));
             _transmitter.Send(_lockToggleConverter.ToOSCMessage(_vrcCamera.Lock.Value));
+            _transmitter.Send(_localPlayerToggleConverter.ToOSCMessage(_vrcCamera.LocalPlayer.Value));
         }
 
         public void Dispose()
@@ -225,6 +236,7 @@ namespace VRCCamera
                 _vrcCamera.Duration.OnValueChanged -= OnDurationChanged;
                 _vrcCamera.ShowUIInCamera.OnValueChanged -= OnShowUIInCameraChanged;
                 _vrcCamera.Lock.OnValueChanged -= OnLockChanged;
+                _vrcCamera.LocalPlayer.OnValueChanged -= OnLocalPlayerChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -22,6 +22,7 @@ namespace VRCCamera
         private readonly PhotoRateConverter _photoRateConverter = new();
         private readonly DurationConverter _durationConverter = new();
         private readonly ShowUIInCameraToggleConverter _showUIInCameraToggleConverter = new();
+        private readonly LockToggleConverter _lockToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -44,6 +45,7 @@ namespace VRCCamera
             _vrcCamera.PhotoRate.OnValueChanged += OnPhotoRateChanged;
             _vrcCamera.Duration.OnValueChanged += OnDurationChanged;
             _vrcCamera.ShowUIInCamera.OnValueChanged += OnShowUIInCameraChanged;
+            _vrcCamera.Lock.OnValueChanged += OnLockChanged;
             
             // Send initial values
             Sync();
@@ -161,8 +163,16 @@ namespace VRCCamera
         private void OnShowUIInCameraChanged(ShowUIInCameraToggle showUIInCamera)
         {
             if (_disposed) return;
-            
+
             var message = _showUIInCameraToggleConverter.ToOSCMessage(showUIInCamera);
+            _transmitter.Send(message);
+        }
+
+        private void OnLockChanged(LockToggle lockToggle)
+        {
+            if (_disposed) return;
+
+            var message = _lockToggleConverter.ToOSCMessage(lockToggle);
             _transmitter.Send(message);
         }
 
@@ -190,6 +200,7 @@ namespace VRCCamera
             _transmitter.Send(_photoRateConverter.ToOSCMessage(_vrcCamera.PhotoRate.Value));
             _transmitter.Send(_durationConverter.ToOSCMessage(_vrcCamera.Duration.Value));
             _transmitter.Send(_showUIInCameraToggleConverter.ToOSCMessage(_vrcCamera.ShowUIInCamera.Value));
+            _transmitter.Send(_lockToggleConverter.ToOSCMessage(_vrcCamera.Lock.Value));
         }
 
         public void Dispose()
@@ -213,6 +224,7 @@ namespace VRCCamera
                 _vrcCamera.PhotoRate.OnValueChanged -= OnPhotoRateChanged;
                 _vrcCamera.Duration.OnValueChanged -= OnDurationChanged;
                 _vrcCamera.ShowUIInCamera.OnValueChanged -= OnShowUIInCameraChanged;
+                _vrcCamera.Lock.OnValueChanged -= OnLockChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -29,6 +29,7 @@ namespace VRCCamera
         private readonly GreenScreenToggleConverter _greenScreenToggleConverter = new();
         private readonly SmoothMovementToggleConverter _smoothMovementToggleConverter = new();
         private readonly LookAtMeToggleConverter _lookAtMeToggleConverter = new();
+        private readonly AutoLevelRollToggleConverter _autoLevelRollToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -58,6 +59,7 @@ namespace VRCCamera
             _vrcCamera.GreenScreen.OnValueChanged += OnGreenScreenChanged;
             _vrcCamera.SmoothMovement.OnValueChanged += OnSmoothMovementChanged;
             _vrcCamera.LookAtMe.OnValueChanged += OnLookAtMeChanged;
+            _vrcCamera.AutoLevelRoll.OnValueChanged += OnAutoLevelRollChanged;
             
             // Send initial values
             Sync();
@@ -236,6 +238,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnAutoLevelRollChanged(AutoLevelRollToggle autoLevelRoll)
+        {
+            if (_disposed) return;
+
+            var message = _autoLevelRollToggleConverter.ToOSCMessage(autoLevelRoll);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -267,6 +277,7 @@ namespace VRCCamera
             _transmitter.Send(_greenScreenToggleConverter.ToOSCMessage(_vrcCamera.GreenScreen.Value));
             _transmitter.Send(_smoothMovementToggleConverter.ToOSCMessage(_vrcCamera.SmoothMovement.Value));
             _transmitter.Send(_lookAtMeToggleConverter.ToOSCMessage(_vrcCamera.LookAtMe.Value));
+            _transmitter.Send(_autoLevelRollToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelRoll.Value));
         }
 
         public void Dispose()
@@ -297,6 +308,7 @@ namespace VRCCamera
                 _vrcCamera.GreenScreen.OnValueChanged -= OnGreenScreenChanged;
                 _vrcCamera.SmoothMovement.OnValueChanged -= OnSmoothMovementChanged;
                 _vrcCamera.LookAtMe.OnValueChanged -= OnLookAtMeChanged;
+                _vrcCamera.AutoLevelRoll.OnValueChanged -= OnAutoLevelRollChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -32,6 +32,7 @@ namespace VRCCamera
         private readonly AutoLevelRollToggleConverter _autoLevelRollToggleConverter = new();
         private readonly AutoLevelPitchToggleConverter _autoLevelPitchToggleConverter = new();
         private readonly FlyingToggleConverter _flyingToggleConverter = new();
+        private readonly TriggerTakesPhotosToggleConverter _triggerTakesPhotosToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -64,6 +65,7 @@ namespace VRCCamera
             _vrcCamera.AutoLevelRoll.OnValueChanged += OnAutoLevelRollChanged;
             _vrcCamera.AutoLevelPitch.OnValueChanged += OnAutoLevelPitchChanged;
             _vrcCamera.Flying.OnValueChanged += OnFlyingChanged;
+            _vrcCamera.TriggerTakesPhotos.OnValueChanged += OnTriggerTakesPhotosChanged;
             
             // Send initial values
             Sync();
@@ -266,6 +268,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnTriggerTakesPhotosChanged(TriggerTakesPhotosToggle trigger)
+        {
+            if (_disposed) return;
+
+            var message = _triggerTakesPhotosToggleConverter.ToOSCMessage(trigger);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -300,6 +310,7 @@ namespace VRCCamera
             _transmitter.Send(_autoLevelRollToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelRoll.Value));
             _transmitter.Send(_autoLevelPitchToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelPitch.Value));
             _transmitter.Send(_flyingToggleConverter.ToOSCMessage(_vrcCamera.Flying.Value));
+            _transmitter.Send(_triggerTakesPhotosToggleConverter.ToOSCMessage(_vrcCamera.TriggerTakesPhotos.Value));
         }
 
         public void Dispose()
@@ -333,6 +344,7 @@ namespace VRCCamera
                 _vrcCamera.AutoLevelRoll.OnValueChanged -= OnAutoLevelRollChanged;
                 _vrcCamera.AutoLevelPitch.OnValueChanged -= OnAutoLevelPitchChanged;
                 _vrcCamera.Flying.OnValueChanged -= OnFlyingChanged;
+                _vrcCamera.TriggerTakesPhotos.OnValueChanged -= OnTriggerTakesPhotosChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -35,6 +35,7 @@ namespace VRCCamera
         private readonly TriggerTakesPhotosToggleConverter _triggerTakesPhotosToggleConverter = new();
         private readonly DollyPathsStayVisibleToggleConverter _dollyPathsStayVisibleToggleConverter = new();
         private readonly CameraEarsToggleConverter _cameraEarsToggleConverter = new();
+        private readonly ShowFocusToggleConverter _showFocusToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -70,6 +71,7 @@ namespace VRCCamera
             _vrcCamera.TriggerTakesPhotos.OnValueChanged += OnTriggerTakesPhotosChanged;
             _vrcCamera.DollyPathsStayVisible.OnValueChanged += OnDollyPathsStayVisibleChanged;
             _vrcCamera.CameraEars.OnValueChanged += OnCameraEarsChanged;
+            _vrcCamera.ShowFocus.OnValueChanged += OnShowFocusChanged;
             
             // Send initial values
             Sync();
@@ -296,6 +298,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnShowFocusChanged(ShowFocusToggle showFocus)
+        {
+            if (_disposed) return;
+
+            var message = _showFocusToggleConverter.ToOSCMessage(showFocus);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -333,6 +343,7 @@ namespace VRCCamera
             _transmitter.Send(_triggerTakesPhotosToggleConverter.ToOSCMessage(_vrcCamera.TriggerTakesPhotos.Value));
             _transmitter.Send(_dollyPathsStayVisibleToggleConverter.ToOSCMessage(_vrcCamera.DollyPathsStayVisible.Value));
             _transmitter.Send(_cameraEarsToggleConverter.ToOSCMessage(_vrcCamera.CameraEars.Value));
+            _transmitter.Send(_showFocusToggleConverter.ToOSCMessage(_vrcCamera.ShowFocus.Value));
         }
 
         public void Dispose()
@@ -369,6 +380,7 @@ namespace VRCCamera
                 _vrcCamera.TriggerTakesPhotos.OnValueChanged -= OnTriggerTakesPhotosChanged;
                 _vrcCamera.DollyPathsStayVisible.OnValueChanged -= OnDollyPathsStayVisibleChanged;
                 _vrcCamera.CameraEars.OnValueChanged -= OnCameraEarsChanged;
+                _vrcCamera.ShowFocus.OnValueChanged -= OnShowFocusChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -26,6 +26,7 @@ namespace VRCCamera
         private readonly LocalPlayerToggleConverter _localPlayerToggleConverter = new();
         private readonly RemotePlayerToggleConverter _remotePlayerToggleConverter = new();
         private readonly EnvironmentToggleConverter _environmentToggleConverter = new();
+        private readonly GreenScreenToggleConverter _greenScreenToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -52,6 +53,7 @@ namespace VRCCamera
             _vrcCamera.LocalPlayer.OnValueChanged += OnLocalPlayerChanged;
             _vrcCamera.RemotePlayer.OnValueChanged += OnRemotePlayerChanged;
             _vrcCamera.Environment.OnValueChanged += OnEnvironmentChanged;
+            _vrcCamera.GreenScreen.OnValueChanged += OnGreenScreenChanged;
             
             // Send initial values
             Sync();
@@ -206,6 +208,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnGreenScreenChanged(GreenScreenToggle greenScreen)
+        {
+            if (_disposed) return;
+
+            var message = _greenScreenToggleConverter.ToOSCMessage(greenScreen);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -234,6 +244,7 @@ namespace VRCCamera
             _transmitter.Send(_localPlayerToggleConverter.ToOSCMessage(_vrcCamera.LocalPlayer.Value));
             _transmitter.Send(_remotePlayerToggleConverter.ToOSCMessage(_vrcCamera.RemotePlayer.Value));
             _transmitter.Send(_environmentToggleConverter.ToOSCMessage(_vrcCamera.Environment.Value));
+            _transmitter.Send(_greenScreenToggleConverter.ToOSCMessage(_vrcCamera.GreenScreen.Value));
         }
 
         public void Dispose()
@@ -261,6 +272,7 @@ namespace VRCCamera
                 _vrcCamera.LocalPlayer.OnValueChanged -= OnLocalPlayerChanged;
                 _vrcCamera.RemotePlayer.OnValueChanged -= OnRemotePlayerChanged;
                 _vrcCamera.Environment.OnValueChanged -= OnEnvironmentChanged;
+                _vrcCamera.GreenScreen.OnValueChanged -= OnGreenScreenChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -36,6 +36,7 @@ namespace VRCCamera
         private readonly DollyPathsStayVisibleToggleConverter _dollyPathsStayVisibleToggleConverter = new();
         private readonly CameraEarsToggleConverter _cameraEarsToggleConverter = new();
         private readonly ShowFocusToggleConverter _showFocusToggleConverter = new();
+        private readonly StreamingToggleConverter _streamingToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -72,6 +73,7 @@ namespace VRCCamera
             _vrcCamera.DollyPathsStayVisible.OnValueChanged += OnDollyPathsStayVisibleChanged;
             _vrcCamera.CameraEars.OnValueChanged += OnCameraEarsChanged;
             _vrcCamera.ShowFocus.OnValueChanged += OnShowFocusChanged;
+            _vrcCamera.Streaming.OnValueChanged += OnStreamingChanged;
             
             // Send initial values
             Sync();
@@ -306,6 +308,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnStreamingChanged(StreamingToggle streaming)
+        {
+            if (_disposed) return;
+
+            var message = _streamingToggleConverter.ToOSCMessage(streaming);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -344,6 +354,7 @@ namespace VRCCamera
             _transmitter.Send(_dollyPathsStayVisibleToggleConverter.ToOSCMessage(_vrcCamera.DollyPathsStayVisible.Value));
             _transmitter.Send(_cameraEarsToggleConverter.ToOSCMessage(_vrcCamera.CameraEars.Value));
             _transmitter.Send(_showFocusToggleConverter.ToOSCMessage(_vrcCamera.ShowFocus.Value));
+            _transmitter.Send(_streamingToggleConverter.ToOSCMessage(_vrcCamera.Streaming.Value));
         }
 
         public void Dispose()
@@ -381,6 +392,7 @@ namespace VRCCamera
                 _vrcCamera.DollyPathsStayVisible.OnValueChanged -= OnDollyPathsStayVisibleChanged;
                 _vrcCamera.CameraEars.OnValueChanged -= OnCameraEarsChanged;
                 _vrcCamera.ShowFocus.OnValueChanged -= OnShowFocusChanged;
+                _vrcCamera.Streaming.OnValueChanged -= OnStreamingChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -28,6 +28,7 @@ namespace VRCCamera
         private readonly EnvironmentToggleConverter _environmentToggleConverter = new();
         private readonly GreenScreenToggleConverter _greenScreenToggleConverter = new();
         private readonly SmoothMovementToggleConverter _smoothMovementToggleConverter = new();
+        private readonly LookAtMeToggleConverter _lookAtMeToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -56,6 +57,7 @@ namespace VRCCamera
             _vrcCamera.Environment.OnValueChanged += OnEnvironmentChanged;
             _vrcCamera.GreenScreen.OnValueChanged += OnGreenScreenChanged;
             _vrcCamera.SmoothMovement.OnValueChanged += OnSmoothMovementChanged;
+            _vrcCamera.LookAtMe.OnValueChanged += OnLookAtMeChanged;
             
             // Send initial values
             Sync();
@@ -226,6 +228,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnLookAtMeChanged(LookAtMeToggle lookAtMe)
+        {
+            if (_disposed) return;
+
+            var message = _lookAtMeToggleConverter.ToOSCMessage(lookAtMe);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -256,6 +266,7 @@ namespace VRCCamera
             _transmitter.Send(_environmentToggleConverter.ToOSCMessage(_vrcCamera.Environment.Value));
             _transmitter.Send(_greenScreenToggleConverter.ToOSCMessage(_vrcCamera.GreenScreen.Value));
             _transmitter.Send(_smoothMovementToggleConverter.ToOSCMessage(_vrcCamera.SmoothMovement.Value));
+            _transmitter.Send(_lookAtMeToggleConverter.ToOSCMessage(_vrcCamera.LookAtMe.Value));
         }
 
         public void Dispose()
@@ -285,6 +296,7 @@ namespace VRCCamera
                 _vrcCamera.Environment.OnValueChanged -= OnEnvironmentChanged;
                 _vrcCamera.GreenScreen.OnValueChanged -= OnGreenScreenChanged;
                 _vrcCamera.SmoothMovement.OnValueChanged -= OnSmoothMovementChanged;
+                _vrcCamera.LookAtMe.OnValueChanged -= OnLookAtMeChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -31,6 +31,7 @@ namespace VRCCamera
         private readonly LookAtMeToggleConverter _lookAtMeToggleConverter = new();
         private readonly AutoLevelRollToggleConverter _autoLevelRollToggleConverter = new();
         private readonly AutoLevelPitchToggleConverter _autoLevelPitchToggleConverter = new();
+        private readonly FlyingToggleConverter _flyingToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -62,6 +63,7 @@ namespace VRCCamera
             _vrcCamera.LookAtMe.OnValueChanged += OnLookAtMeChanged;
             _vrcCamera.AutoLevelRoll.OnValueChanged += OnAutoLevelRollChanged;
             _vrcCamera.AutoLevelPitch.OnValueChanged += OnAutoLevelPitchChanged;
+            _vrcCamera.Flying.OnValueChanged += OnFlyingChanged;
             
             // Send initial values
             Sync();
@@ -256,6 +258,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnFlyingChanged(FlyingToggle flying)
+        {
+            if (_disposed) return;
+
+            var message = _flyingToggleConverter.ToOSCMessage(flying);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -289,6 +299,7 @@ namespace VRCCamera
             _transmitter.Send(_lookAtMeToggleConverter.ToOSCMessage(_vrcCamera.LookAtMe.Value));
             _transmitter.Send(_autoLevelRollToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelRoll.Value));
             _transmitter.Send(_autoLevelPitchToggleConverter.ToOSCMessage(_vrcCamera.AutoLevelPitch.Value));
+            _transmitter.Send(_flyingToggleConverter.ToOSCMessage(_vrcCamera.Flying.Value));
         }
 
         public void Dispose()
@@ -321,6 +332,7 @@ namespace VRCCamera
                 _vrcCamera.LookAtMe.OnValueChanged -= OnLookAtMeChanged;
                 _vrcCamera.AutoLevelRoll.OnValueChanged -= OnAutoLevelRollChanged;
                 _vrcCamera.AutoLevelPitch.OnValueChanged -= OnAutoLevelPitchChanged;
+                _vrcCamera.Flying.OnValueChanged -= OnFlyingChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -34,6 +34,7 @@ namespace VRCCamera
         private readonly FlyingToggleConverter _flyingToggleConverter = new();
         private readonly TriggerTakesPhotosToggleConverter _triggerTakesPhotosToggleConverter = new();
         private readonly DollyPathsStayVisibleToggleConverter _dollyPathsStayVisibleToggleConverter = new();
+        private readonly CameraEarsToggleConverter _cameraEarsToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -68,6 +69,7 @@ namespace VRCCamera
             _vrcCamera.Flying.OnValueChanged += OnFlyingChanged;
             _vrcCamera.TriggerTakesPhotos.OnValueChanged += OnTriggerTakesPhotosChanged;
             _vrcCamera.DollyPathsStayVisible.OnValueChanged += OnDollyPathsStayVisibleChanged;
+            _vrcCamera.CameraEars.OnValueChanged += OnCameraEarsChanged;
             
             // Send initial values
             Sync();
@@ -286,6 +288,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnCameraEarsChanged(CameraEarsToggle cameraEars)
+        {
+            if (_disposed) return;
+
+            var message = _cameraEarsToggleConverter.ToOSCMessage(cameraEars);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -322,6 +332,7 @@ namespace VRCCamera
             _transmitter.Send(_flyingToggleConverter.ToOSCMessage(_vrcCamera.Flying.Value));
             _transmitter.Send(_triggerTakesPhotosToggleConverter.ToOSCMessage(_vrcCamera.TriggerTakesPhotos.Value));
             _transmitter.Send(_dollyPathsStayVisibleToggleConverter.ToOSCMessage(_vrcCamera.DollyPathsStayVisible.Value));
+            _transmitter.Send(_cameraEarsToggleConverter.ToOSCMessage(_vrcCamera.CameraEars.Value));
         }
 
         public void Dispose()
@@ -357,6 +368,7 @@ namespace VRCCamera
                 _vrcCamera.Flying.OnValueChanged -= OnFlyingChanged;
                 _vrcCamera.TriggerTakesPhotos.OnValueChanged -= OnTriggerTakesPhotosChanged;
                 _vrcCamera.DollyPathsStayVisible.OnValueChanged -= OnDollyPathsStayVisibleChanged;
+                _vrcCamera.CameraEars.OnValueChanged -= OnCameraEarsChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -24,6 +24,7 @@ namespace VRCCamera
         private readonly ShowUIInCameraToggleConverter _showUIInCameraToggleConverter = new();
         private readonly LockToggleConverter _lockToggleConverter = new();
         private readonly LocalPlayerToggleConverter _localPlayerToggleConverter = new();
+        private readonly RemotePlayerToggleConverter _remotePlayerToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -48,6 +49,7 @@ namespace VRCCamera
             _vrcCamera.ShowUIInCamera.OnValueChanged += OnShowUIInCameraChanged;
             _vrcCamera.Lock.OnValueChanged += OnLockChanged;
             _vrcCamera.LocalPlayer.OnValueChanged += OnLocalPlayerChanged;
+            _vrcCamera.RemotePlayer.OnValueChanged += OnRemotePlayerChanged;
             
             // Send initial values
             Sync();
@@ -186,6 +188,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnRemotePlayerChanged(RemotePlayerToggle remotePlayer)
+        {
+            if (_disposed) return;
+
+            var message = _remotePlayerToggleConverter.ToOSCMessage(remotePlayer);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -212,6 +222,7 @@ namespace VRCCamera
             _transmitter.Send(_showUIInCameraToggleConverter.ToOSCMessage(_vrcCamera.ShowUIInCamera.Value));
             _transmitter.Send(_lockToggleConverter.ToOSCMessage(_vrcCamera.Lock.Value));
             _transmitter.Send(_localPlayerToggleConverter.ToOSCMessage(_vrcCamera.LocalPlayer.Value));
+            _transmitter.Send(_remotePlayerToggleConverter.ToOSCMessage(_vrcCamera.RemotePlayer.Value));
         }
 
         public void Dispose()
@@ -237,6 +248,7 @@ namespace VRCCamera
                 _vrcCamera.ShowUIInCamera.OnValueChanged -= OnShowUIInCameraChanged;
                 _vrcCamera.Lock.OnValueChanged -= OnLockChanged;
                 _vrcCamera.LocalPlayer.OnValueChanged -= OnLocalPlayerChanged;
+                _vrcCamera.RemotePlayer.OnValueChanged -= OnRemotePlayerChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -27,6 +27,7 @@ namespace VRCCamera
         private readonly RemotePlayerToggleConverter _remotePlayerToggleConverter = new();
         private readonly EnvironmentToggleConverter _environmentToggleConverter = new();
         private readonly GreenScreenToggleConverter _greenScreenToggleConverter = new();
+        private readonly SmoothMovementToggleConverter _smoothMovementToggleConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -54,6 +55,7 @@ namespace VRCCamera
             _vrcCamera.RemotePlayer.OnValueChanged += OnRemotePlayerChanged;
             _vrcCamera.Environment.OnValueChanged += OnEnvironmentChanged;
             _vrcCamera.GreenScreen.OnValueChanged += OnGreenScreenChanged;
+            _vrcCamera.SmoothMovement.OnValueChanged += OnSmoothMovementChanged;
             
             // Send initial values
             Sync();
@@ -216,6 +218,14 @@ namespace VRCCamera
             _transmitter.Send(message);
         }
 
+        private void OnSmoothMovementChanged(SmoothMovementToggle smoothMovement)
+        {
+            if (_disposed) return;
+
+            var message = _smoothMovementToggleConverter.ToOSCMessage(smoothMovement);
+            _transmitter.Send(message);
+        }
+
         public void Sync()
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
@@ -245,6 +255,7 @@ namespace VRCCamera
             _transmitter.Send(_remotePlayerToggleConverter.ToOSCMessage(_vrcCamera.RemotePlayer.Value));
             _transmitter.Send(_environmentToggleConverter.ToOSCMessage(_vrcCamera.Environment.Value));
             _transmitter.Send(_greenScreenToggleConverter.ToOSCMessage(_vrcCamera.GreenScreen.Value));
+            _transmitter.Send(_smoothMovementToggleConverter.ToOSCMessage(_vrcCamera.SmoothMovement.Value));
         }
 
         public void Dispose()
@@ -273,6 +284,7 @@ namespace VRCCamera
                 _vrcCamera.RemotePlayer.OnValueChanged -= OnRemotePlayerChanged;
                 _vrcCamera.Environment.OnValueChanged -= OnEnvironmentChanged;
                 _vrcCamera.GreenScreen.OnValueChanged -= OnGreenScreenChanged;
+                _vrcCamera.SmoothMovement.OnValueChanged -= OnSmoothMovementChanged;
             }
             
             _transmitter?.Dispose();

--- a/Scripts/Runtime/Parameters/AutoLevelPitchToggle.cs
+++ b/Scripts/Runtime/Parameters/AutoLevelPitchToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling Auto Level (Pitch) for the user camera
+    /// </summary>
+    public readonly struct AutoLevelPitchToggle : IEquatable<AutoLevelPitchToggle>
+    {
+        public readonly bool Value;
+
+        public AutoLevelPitchToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(AutoLevelPitchToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is AutoLevelPitchToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(AutoLevelPitchToggle left, AutoLevelPitchToggle right) => left.Equals(right);
+        public static bool operator !=(AutoLevelPitchToggle left, AutoLevelPitchToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(AutoLevelPitchToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/AutoLevelPitchToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/AutoLevelPitchToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: daebc58ac2888e944ae8cf187d0f3a66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/AutoLevelRollToggle.cs
+++ b/Scripts/Runtime/Parameters/AutoLevelRollToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling Auto Level (Roll) for the user camera
+    /// </summary>
+    public readonly struct AutoLevelRollToggle : IEquatable<AutoLevelRollToggle>
+    {
+        public readonly bool Value;
+
+        public AutoLevelRollToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(AutoLevelRollToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is AutoLevelRollToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(AutoLevelRollToggle left, AutoLevelRollToggle right) => left.Equals(right);
+        public static bool operator !=(AutoLevelRollToggle left, AutoLevelRollToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(AutoLevelRollToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/AutoLevelRollToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/AutoLevelRollToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0471cd61cf95a7748a6e33cd81a73e4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/CameraEarsToggle.cs
+++ b/Scripts/Runtime/Parameters/CameraEarsToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling Camera Ears (use avatar ears for audio) in the user camera
+    /// </summary>
+    public readonly struct CameraEarsToggle : IEquatable<CameraEarsToggle>
+    {
+        public readonly bool Value;
+
+        public CameraEarsToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(CameraEarsToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is CameraEarsToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(CameraEarsToggle left, CameraEarsToggle right) => left.Equals(right);
+        public static bool operator !=(CameraEarsToggle left, CameraEarsToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(CameraEarsToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/CameraEarsToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/CameraEarsToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcad2a7e252ec4d479dd1524b582ac47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/DollyPathsStayVisibleToggle.cs
+++ b/Scripts/Runtime/Parameters/DollyPathsStayVisibleToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling visibility of dolly paths in the user camera
+    /// </summary>
+    public readonly struct DollyPathsStayVisibleToggle : IEquatable<DollyPathsStayVisibleToggle>
+    {
+        public readonly bool Value;
+
+        public DollyPathsStayVisibleToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(DollyPathsStayVisibleToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is DollyPathsStayVisibleToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(DollyPathsStayVisibleToggle left, DollyPathsStayVisibleToggle right) => left.Equals(right);
+        public static bool operator !=(DollyPathsStayVisibleToggle left, DollyPathsStayVisibleToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(DollyPathsStayVisibleToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/DollyPathsStayVisibleToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/DollyPathsStayVisibleToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48ff8ec96c637b24187cc1815d92d68a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/EnvironmentToggle.cs
+++ b/Scripts/Runtime/Parameters/EnvironmentToggle.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents the toggle state for showing the environment in the VRChat camera
+    /// </summary>
+    public readonly struct EnvironmentToggle : IEquatable<EnvironmentToggle>
+    {
+        public readonly bool Value;
+
+        public EnvironmentToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(EnvironmentToggle other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is EnvironmentToggle other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static bool operator ==(EnvironmentToggle left, EnvironmentToggle right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(EnvironmentToggle left, EnvironmentToggle right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static implicit operator bool(EnvironmentToggle toggle)
+        {
+            return toggle.Value;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+    }
+}
+

--- a/Scripts/Runtime/Parameters/EnvironmentToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/EnvironmentToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02bba0b15d7bac848acde47b3b6542aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/FlyingToggle.cs
+++ b/Scripts/Runtime/Parameters/FlyingToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling Flying mode for the VRChat user camera
+    /// </summary>
+    public readonly struct FlyingToggle : IEquatable<FlyingToggle>
+    {
+        public readonly bool Value;
+
+        public FlyingToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(FlyingToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is FlyingToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(FlyingToggle left, FlyingToggle right) => left.Equals(right);
+        public static bool operator !=(FlyingToggle left, FlyingToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(FlyingToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/FlyingToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/FlyingToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd6ae6d515d01c14692cd97e4044b383
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/GreenScreenToggle.cs
+++ b/Scripts/Runtime/Parameters/GreenScreenToggle.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling Green Screen mode in the VRChat user camera
+    /// </summary>
+    public readonly struct GreenScreenToggle : IEquatable<GreenScreenToggle>
+    {
+        public readonly bool Value;
+
+        public GreenScreenToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(GreenScreenToggle other) => Value == other.Value;
+
+        public override bool Equals(object obj) => obj is GreenScreenToggle other && Equals(other);
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(GreenScreenToggle left, GreenScreenToggle right) => left.Equals(right);
+        public static bool operator !=(GreenScreenToggle left, GreenScreenToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(GreenScreenToggle toggle) => toggle.Value;
+
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/GreenScreenToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/GreenScreenToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9f490266f6cae1498acfc82d707ace1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/LocalPlayerToggle.cs
+++ b/Scripts/Runtime/Parameters/LocalPlayerToggle.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents the toggle state for showing the local player in the VRChat camera
+    /// </summary>
+    public readonly struct LocalPlayerToggle : IEquatable<LocalPlayerToggle>
+    {
+        public readonly bool Value;
+
+        public LocalPlayerToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(LocalPlayerToggle other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is LocalPlayerToggle other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static bool operator ==(LocalPlayerToggle left, LocalPlayerToggle right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(LocalPlayerToggle left, LocalPlayerToggle right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static implicit operator bool(LocalPlayerToggle toggle)
+        {
+            return toggle.Value;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+    }
+}
+

--- a/Scripts/Runtime/Parameters/LocalPlayerToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/LocalPlayerToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fcbc30808bced0499655852a1159432
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/LockToggle.cs
+++ b/Scripts/Runtime/Parameters/LockToggle.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents the toggle state for locking the VRChat camera position
+    /// </summary>
+    public readonly struct LockToggle : IEquatable<LockToggle>
+    {
+        public readonly bool Value;
+
+        public LockToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(LockToggle other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is LockToggle other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static bool operator ==(LockToggle left, LockToggle right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(LockToggle left, LockToggle right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static implicit operator bool(LockToggle toggle)
+        {
+            return toggle.Value;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+    }
+}
+

--- a/Scripts/Runtime/Parameters/LockToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/LockToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 331dc92cab3d79149a651747f063d16e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/LookAtMeToggle.cs
+++ b/Scripts/Runtime/Parameters/LookAtMeToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling Look At Me mode for the user camera
+    /// </summary>
+    public readonly struct LookAtMeToggle : IEquatable<LookAtMeToggle>
+    {
+        public readonly bool Value;
+
+        public LookAtMeToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(LookAtMeToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is LookAtMeToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(LookAtMeToggle left, LookAtMeToggle right) => left.Equals(right);
+        public static bool operator !=(LookAtMeToggle left, LookAtMeToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(LookAtMeToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/LookAtMeToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/LookAtMeToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a81e52cf843c3f1448e16f86f1c4c50e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/OrientationIsLandscapeToggle.cs
+++ b/Scripts/Runtime/Parameters/OrientationIsLandscapeToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling landscape orientation for the user camera
+    /// </summary>
+    public readonly struct OrientationIsLandscapeToggle : IEquatable<OrientationIsLandscapeToggle>
+    {
+        public readonly bool Value;
+
+        public OrientationIsLandscapeToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(OrientationIsLandscapeToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is OrientationIsLandscapeToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(OrientationIsLandscapeToggle left, OrientationIsLandscapeToggle right) => left.Equals(right);
+        public static bool operator !=(OrientationIsLandscapeToggle left, OrientationIsLandscapeToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(OrientationIsLandscapeToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/OrientationIsLandscapeToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/OrientationIsLandscapeToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8844d6dd18b26404aae891bd1178be6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/RemotePlayerToggle.cs
+++ b/Scripts/Runtime/Parameters/RemotePlayerToggle.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents the toggle state for showing remote players in the VRChat camera
+    /// </summary>
+    public readonly struct RemotePlayerToggle : IEquatable<RemotePlayerToggle>
+    {
+        public readonly bool Value;
+
+        public RemotePlayerToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(RemotePlayerToggle other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RemotePlayerToggle other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static bool operator ==(RemotePlayerToggle left, RemotePlayerToggle right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RemotePlayerToggle left, RemotePlayerToggle right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static implicit operator bool(RemotePlayerToggle toggle)
+        {
+            return toggle.Value;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+    }
+}
+

--- a/Scripts/Runtime/Parameters/RemotePlayerToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/RemotePlayerToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 240e42b95af3003409374e966e35ff1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/RollWhileFlyingToggle.cs
+++ b/Scripts/Runtime/Parameters/RollWhileFlyingToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling roll input while flying for the user camera
+    /// </summary>
+    public readonly struct RollWhileFlyingToggle : IEquatable<RollWhileFlyingToggle>
+    {
+        public readonly bool Value;
+
+        public RollWhileFlyingToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(RollWhileFlyingToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is RollWhileFlyingToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(RollWhileFlyingToggle left, RollWhileFlyingToggle right) => left.Equals(right);
+        public static bool operator !=(RollWhileFlyingToggle left, RollWhileFlyingToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(RollWhileFlyingToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/RollWhileFlyingToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/RollWhileFlyingToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c74514cea94e75448890d00a677360fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/ShowFocusToggle.cs
+++ b/Scripts/Runtime/Parameters/ShowFocusToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling focus visualization in the user camera
+    /// </summary>
+    public readonly struct ShowFocusToggle : IEquatable<ShowFocusToggle>
+    {
+        public readonly bool Value;
+
+        public ShowFocusToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(ShowFocusToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is ShowFocusToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(ShowFocusToggle left, ShowFocusToggle right) => left.Equals(right);
+        public static bool operator !=(ShowFocusToggle left, ShowFocusToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(ShowFocusToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/ShowFocusToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/ShowFocusToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cb24378b4450d943b9d908a52664357
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/ShowUIInCameraToggle.cs
+++ b/Scripts/Runtime/Parameters/ShowUIInCameraToggle.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents the toggle state for showing UI elements in VRChat camera view
+    /// </summary>
+    public readonly struct ShowUIInCameraToggle : IEquatable<ShowUIInCameraToggle>
+    {
+        public readonly bool Value;
+
+        public ShowUIInCameraToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(ShowUIInCameraToggle other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ShowUIInCameraToggle other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static bool operator ==(ShowUIInCameraToggle left, ShowUIInCameraToggle right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ShowUIInCameraToggle left, ShowUIInCameraToggle right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static implicit operator bool(ShowUIInCameraToggle toggle)
+        {
+            return toggle.Value;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+    }
+}

--- a/Scripts/Runtime/Parameters/ShowUIInCameraToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/ShowUIInCameraToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40111e008e839b047accc47a9e5d29ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/SmoothMovementToggle.cs
+++ b/Scripts/Runtime/Parameters/SmoothMovementToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling smooth movement for the VRChat user camera
+    /// </summary>
+    public readonly struct SmoothMovementToggle : IEquatable<SmoothMovementToggle>
+    {
+        public readonly bool Value;
+
+        public SmoothMovementToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(SmoothMovementToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is SmoothMovementToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(SmoothMovementToggle left, SmoothMovementToggle right) => left.Equals(right);
+        public static bool operator !=(SmoothMovementToggle left, SmoothMovementToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(SmoothMovementToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/SmoothMovementToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/SmoothMovementToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e2d562c77be5254fbd40ee65194749d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/StreamingToggle.cs
+++ b/Scripts/Runtime/Parameters/StreamingToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling Streaming mode for the user camera
+    /// </summary>
+    public readonly struct StreamingToggle : IEquatable<StreamingToggle>
+    {
+        public readonly bool Value;
+
+        public StreamingToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(StreamingToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is StreamingToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(StreamingToggle left, StreamingToggle right) => left.Equals(right);
+        public static bool operator !=(StreamingToggle left, StreamingToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(StreamingToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/StreamingToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/StreamingToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5713e6e36f7a56f4aa938d90f38282d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Parameters/TriggerTakesPhotosToggle.cs
+++ b/Scripts/Runtime/Parameters/TriggerTakesPhotosToggle.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Parameters
+{
+    /// <summary>
+    /// Represents enabling/disabling the behavior where trigger input takes photos
+    /// </summary>
+    public readonly struct TriggerTakesPhotosToggle : IEquatable<TriggerTakesPhotosToggle>
+    {
+        public readonly bool Value;
+
+        public TriggerTakesPhotosToggle(bool value)
+        {
+            Value = value;
+        }
+
+        public bool Equals(TriggerTakesPhotosToggle other) => Value == other.Value;
+        public override bool Equals(object obj) => obj is TriggerTakesPhotosToggle other && Equals(other);
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public static bool operator ==(TriggerTakesPhotosToggle left, TriggerTakesPhotosToggle right) => left.Equals(right);
+        public static bool operator !=(TriggerTakesPhotosToggle left, TriggerTakesPhotosToggle right) => !left.Equals(right);
+
+        public static implicit operator bool(TriggerTakesPhotosToggle toggle) => toggle.Value;
+        public override string ToString() => Value.ToString();
+    }
+}
+

--- a/Scripts/Runtime/Parameters/TriggerTakesPhotosToggle.cs.meta
+++ b/Scripts/Runtime/Parameters/TriggerTakesPhotosToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87836e993e7d8874896eb60d5a3b54ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/AutoLevelPitchToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/AutoLevelPitchToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class AutoLevelPitchToggleConverterUnitTests
+    {
+        private AutoLevelPitchToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new AutoLevelPitchToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new AutoLevelPitchToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.AutoLevelPitch.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new AutoLevelPitchToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.AutoLevelPitch.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelPitch, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/AutoLevelPitchToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/AutoLevelPitchToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0dc341e0028a9734aa094580a25b84dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/AutoLevelRollToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/AutoLevelRollToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class AutoLevelRollToggleConverterUnitTests
+    {
+        private AutoLevelRollToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new AutoLevelRollToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new AutoLevelRollToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.AutoLevelRoll.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new AutoLevelRollToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.AutoLevelRoll.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.AutoLevelRoll, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/AutoLevelRollToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/AutoLevelRollToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 265b6620027fabb4db0f791471573c5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/CameraEarsToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/CameraEarsToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class CameraEarsToggleConverterUnitTests
+    {
+        private CameraEarsToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new CameraEarsToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new CameraEarsToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.CameraEars.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new CameraEarsToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.CameraEars.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.CameraEars, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/CameraEarsToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/CameraEarsToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 147cb443474d32346b61a3c7e0083b81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/DollyPathsStayVisibleToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/DollyPathsStayVisibleToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class DollyPathsStayVisibleToggleConverterUnitTests
+    {
+        private DollyPathsStayVisibleToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new DollyPathsStayVisibleToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new DollyPathsStayVisibleToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.DollyPathsStayVisible.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new DollyPathsStayVisibleToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.DollyPathsStayVisible.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.DollyPathsStayVisible, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/DollyPathsStayVisibleToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/DollyPathsStayVisibleToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5373f3954f7477c4b84885fed7f1c508
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/EnvironmentToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/EnvironmentToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class EnvironmentToggleConverterUnitTests
+    {
+        private EnvironmentToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new EnvironmentToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new EnvironmentToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.Environment.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new EnvironmentToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.Environment.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Environment, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/EnvironmentToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/EnvironmentToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06b7186a97b00e14382957d1ffee3dd5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/FlyingToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/FlyingToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class FlyingToggleConverterUnitTests
+    {
+        private FlyingToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new FlyingToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new FlyingToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.Flying.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new FlyingToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.Flying.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Flying, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/FlyingToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/FlyingToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90363c41ef571b148806d08f94f59665
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/GreenScreenToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/GreenScreenToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class GreenScreenToggleConverterUnitTests
+    {
+        private GreenScreenToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new GreenScreenToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new GreenScreenToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.GreenScreen.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new GreenScreenToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.GreenScreen.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.GreenScreen, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/GreenScreenToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/GreenScreenToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39b364eb27b129d499c5487900fa3811
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/LocalPlayerToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/LocalPlayerToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class LocalPlayerToggleConverterUnitTests
+    {
+        private LocalPlayerToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new LocalPlayerToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new LocalPlayerToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.LocalPlayer.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new LocalPlayerToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.LocalPlayer.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LocalPlayer, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/LocalPlayerToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/LocalPlayerToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 621efbb9278c6014fbfae7c159cb610d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/LockToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/LockToggleConverterUnitTests.cs
@@ -1,0 +1,121 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class LockToggleConverterUnitTests
+    {
+        private LockToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new LockToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_WithTrueToggle_CreatesCorrectMessage()
+        {
+            var message = _converter.ToOSCMessage(new LockToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.Lock.Value, message.Address.Value);
+            Assert.AreEqual(1, message.Arguments.Length);
+            Assert.AreEqual(true, message.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, message.Arguments[0].Type);
+            Assert.AreEqual("T", message.TypeTag.Value);
+        }
+
+        [Test]
+        public void ToOSCMessage_WithFalseToggle_CreatesCorrectMessage()
+        {
+            var message = _converter.ToOSCMessage(new LockToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.Lock.Value, message.Address.Value);
+            Assert.AreEqual(1, message.Arguments.Length);
+            Assert.AreEqual(false, message.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, message.Arguments[0].Type);
+            Assert.AreEqual("F", message.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithBooleanTrueArgument_ReturnsCorrectToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument(true) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsTrue(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithBooleanFalseArgument_ReturnsCorrectToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument(false) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsFalse(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithInt32OneArgument_ReturnsTrueToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument(1) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsTrue(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithInt32ZeroArgument_ReturnsFalseToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument(0) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsFalse(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithFloat32NonZeroArgument_ReturnsTrueToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument(1.0f) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsTrue(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithFloat32ZeroArgument_ReturnsFalseToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument(0.0f) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsFalse(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithWrongAddress_ReturnsFalseToggle()
+        {
+            var message = new Message(new Address("/some/other/address"), new[] { new Argument(true) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsFalse(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithEmptyArguments_ReturnsFalseToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, System.Array.Empty<Argument>());
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsFalse(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithTooManyArguments_UsesFirstArgument()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument(true), new Argument(false) });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsTrue(toggle.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithUnsupportedArgumentType_ReturnsFalseToggle()
+        {
+            var message = new Message(OSCCameraEndpoints.Lock, new[] { new Argument("true") });
+            var toggle = _converter.FromOSCMessage(message);
+            Assert.IsFalse(toggle.Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/LockToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/LockToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4648ad49f09ae9d4c809eef5c01fc6ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/LookAtMeToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/LookAtMeToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class LookAtMeToggleConverterUnitTests
+    {
+        private LookAtMeToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new LookAtMeToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new LookAtMeToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.LookAtMe.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new LookAtMeToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.LookAtMe.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.LookAtMe, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/LookAtMeToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/LookAtMeToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67ac49a80219bc14c951e447e7b9efa3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/OrientationIsLandscapeToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/OrientationIsLandscapeToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class OrientationIsLandscapeToggleConverterUnitTests
+    {
+        private OrientationIsLandscapeToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new OrientationIsLandscapeToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new OrientationIsLandscapeToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.OrientationIsLandscape.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new OrientationIsLandscapeToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.OrientationIsLandscape.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/OrientationIsLandscapeToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/OrientationIsLandscapeToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: beb5b84f5a7a4744a8fd1a00bbae04fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/RemotePlayerToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/RemotePlayerToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class RemotePlayerToggleConverterUnitTests
+    {
+        private RemotePlayerToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new RemotePlayerToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new RemotePlayerToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.RemotePlayer.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new RemotePlayerToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.RemotePlayer.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RemotePlayer, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/RemotePlayerToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/RemotePlayerToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 801c133c7f891a1409c0d1d50c2b8aa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/RollWhileFlyingToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/RollWhileFlyingToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class RollWhileFlyingToggleConverterUnitTests
+    {
+        private RollWhileFlyingToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new RollWhileFlyingToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new RollWhileFlyingToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.RollWhileFlying.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new RollWhileFlyingToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.RollWhileFlying.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.RollWhileFlying, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/RollWhileFlyingToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/RollWhileFlyingToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e1d6f1699cd8ee4e8d40cdf7c0b197c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/ShowFocusToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/ShowFocusToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class ShowFocusToggleConverterUnitTests
+    {
+        private ShowFocusToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new ShowFocusToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new ShowFocusToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.ShowFocus.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new ShowFocusToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.ShowFocus.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.ShowFocus, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/ShowFocusToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/ShowFocusToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76dd2fa47b488df4b886da03813f3b6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/ShowUIInCameraToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/ShowUIInCameraToggleConverterUnitTests.cs
@@ -1,0 +1,201 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class ShowUIInCameraToggleConverterUnitTests
+    {
+        private ShowUIInCameraToggleConverter _converter;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new ShowUIInCameraToggleConverter();
+        }
+        
+        [Test]
+        public void ToOSCMessage_WithTrueToggle_CreatesCorrectMessage()
+        {
+            // Arrange
+            var toggle = new ShowUIInCameraToggle(true);
+            
+            // Act
+            var message = _converter.ToOSCMessage(toggle);
+            
+            // Assert
+            Assert.AreEqual(OSCCameraEndpoints.ShowUIInCamera.Value, message.Address.Value);
+            Assert.AreEqual(1, message.Arguments.Length);
+            Assert.AreEqual(true, message.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, message.Arguments[0].Type);
+            Assert.AreEqual("T", message.TypeTag.Value);
+        }
+        
+        [Test]
+        public void ToOSCMessage_WithFalseToggle_CreatesCorrectMessage()
+        {
+            // Arrange
+            var toggle = new ShowUIInCameraToggle(false);
+            
+            // Act
+            var message = _converter.ToOSCMessage(toggle);
+            
+            // Assert
+            Assert.AreEqual(OSCCameraEndpoints.ShowUIInCamera.Value, message.Address.Value);
+            Assert.AreEqual(1, message.Arguments.Length);
+            Assert.AreEqual(false, message.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, message.Arguments[0].Type);
+            Assert.AreEqual("F", message.TypeTag.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithBooleanTrueArgument_ReturnsCorrectToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument(true) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsTrue(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithBooleanFalseArgument_ReturnsCorrectToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument(false) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsFalse(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithInt32OneArgument_ReturnsTrueToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument(1) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsTrue(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithInt32ZeroArgument_ReturnsFalseToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument(0) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsFalse(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithFloat32NonZeroArgument_ReturnsTrueToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument(1.0f) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsTrue(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithFloat32ZeroArgument_ReturnsFalseToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument(0.0f) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsFalse(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithWrongAddress_ReturnsFalseToggle()
+        {
+            // Arrange
+            var address = new Address("/some/other/address");
+            var arguments = new[] { new Argument(true) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsFalse(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithEmptyArguments_ReturnsFalseToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var message = new Message(address, System.Array.Empty<Argument>());
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsFalse(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithTooManyArguments_UsesFirstArgument()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument(true), new Argument(false) };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsTrue(toggle.Value);
+        }
+        
+        [Test]
+        public void FromOSCMessage_WithUnsupportedArgumentType_ReturnsFalseToggle()
+        {
+            // Arrange
+            var address = OSCCameraEndpoints.ShowUIInCamera;
+            var arguments = new[] { new Argument("true") };
+            var message = new Message(address, arguments);
+            
+            // Act
+            var toggle = _converter.FromOSCMessage(message);
+            
+            // Assert
+            Assert.IsFalse(toggle.Value);
+        }
+    }
+}

--- a/Tests/Editor/OSC/ShowUIInCameraToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/ShowUIInCameraToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b72a77ceea8f44d9be605b5c666528
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/SmoothMovementToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/SmoothMovementToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class SmoothMovementToggleConverterUnitTests
+    {
+        private SmoothMovementToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new SmoothMovementToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new SmoothMovementToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.SmoothMovement.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new SmoothMovementToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.SmoothMovement.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.SmoothMovement, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/SmoothMovementToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/SmoothMovementToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 729393c4a25126c4c9eb26ddc5876cc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/StreamingToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/StreamingToggleConverterUnitTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class StreamingToggleConverterUnitTests
+    {
+        private StreamingToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new StreamingToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new StreamingToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.Streaming.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new StreamingToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.Streaming.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.Streaming, new[] { new Argument("true") })).Value);
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/StreamingToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/StreamingToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b096489803e025c44a23386897fb4659
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/TriggerTakesPhotosToggleConverterUnitTests.cs
+++ b/Tests/Editor/OSC/TriggerTakesPhotosToggleConverterUnitTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class TriggerTakesPhotosToggleConverterUnitTests
+    {
+        private TriggerTakesPhotosToggleConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new TriggerTakesPhotosToggleConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithBool()
+        {
+            var msgTrue = _converter.ToOSCMessage(new TriggerTakesPhotosToggle(true));
+            Assert.AreEqual(OSCCameraEndpoints.TriggerTakesPhotos.Value, msgTrue.Address.Value);
+            Assert.AreEqual(1, msgTrue.Arguments.Length);
+            Assert.AreEqual(true, msgTrue.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgTrue.Arguments[0].Type);
+            Assert.AreEqual("T", msgTrue.TypeTag.Value);
+
+            var msgFalse = _converter.ToOSCMessage(new TriggerTakesPhotosToggle(false));
+            Assert.AreEqual(OSCCameraEndpoints.TriggerTakesPhotos.Value, msgFalse.Address.Value);
+            Assert.AreEqual(1, msgFalse.Arguments.Length);
+            Assert.AreEqual(false, msgFalse.Arguments[0].Value);
+            Assert.AreEqual(Argument.ValueType.Bool, msgFalse.Arguments[0].Type);
+            Assert.AreEqual("F", msgFalse.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_ParsesVariousTypes()
+        {
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument(false) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument(1) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument(0) })).Value);
+            Assert.IsTrue(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument(1.0f) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument(0.0f) })).Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(true) })).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, System.Array.Empty<Argument>())).Value);
+            Assert.IsFalse(_converter.FromOSCMessage(new Message(OSCCameraEndpoints.TriggerTakesPhotos, new[] { new Argument("true") })).Value);
+        }
+    }
+}

--- a/Tests/Editor/OSC/TriggerTakesPhotosToggleConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/TriggerTakesPhotosToggleConverterUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e09bb2410994a143a52873acd75a492
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 31 initial values (14 sliders + 17 toggles)
-            Assert.AreEqual(31, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 32 initial values (14 sliders + 18 toggles)
+            Assert.AreEqual(32, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 31 parameters (14 sliders + 17 toggles) + 1 from SetExposure = 32
-            Assert.AreEqual(32, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 32 parameters (14 sliders + 18 toggles) + 1 from SetExposure = 33
+            Assert.AreEqual(33, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 31 messages (14 sliders + 17 toggles)
-            Assert.AreEqual(31, _mockTransmitter.SendCallCount);
+            // Force sends all 32 messages (14 sliders + 18 toggles)
+            Assert.AreEqual(32, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(31, secondCallCount); // 31 messages per Sync call (14 sliders + 17 toggles)
+            Assert.AreEqual(32, secondCallCount); // 32 messages per Sync call (14 sliders + 18 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 23 initial values (14 sliders + 9 toggles)
-            Assert.AreEqual(23, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 24 initial values (14 sliders + 10 toggles)
+            Assert.AreEqual(24, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 23 parameters (14 sliders + 9 toggles) + 1 from SetExposure = 24
-            Assert.AreEqual(24, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 24 parameters (14 sliders + 10 toggles) + 1 from SetExposure = 25
+            Assert.AreEqual(25, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 23 messages (14 sliders + 9 toggles)
-            Assert.AreEqual(23, _mockTransmitter.SendCallCount);
+            // Force sends all 24 messages (14 sliders + 10 toggles)
+            Assert.AreEqual(24, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(23, secondCallCount); // 23 messages per Sync call (14 sliders + 9 toggles)
+            Assert.AreEqual(24, secondCallCount); // 24 messages per Sync call (14 sliders + 10 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 20 initial values (14 sliders + 6 toggles)
-            Assert.AreEqual(20, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 21 initial values (14 sliders + 7 toggles)
+            Assert.AreEqual(21, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 20 parameters (14 sliders + 6 toggles) + 1 from SetExposure = 21
-            Assert.AreEqual(21, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 21 parameters (14 sliders + 7 toggles) + 1 from SetExposure = 22
+            Assert.AreEqual(22, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(20, secondCallCount); // 20 messages per Sync call (14 sliders + 6 toggles)
+            Assert.AreEqual(21, secondCallCount); // 21 messages per Sync call (14 sliders + 7 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 15 initial values (14 sliders + 1 toggle)
-            Assert.AreEqual(15, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 16 initial values (14 sliders + 2 toggles)
+            Assert.AreEqual(16, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 15 parameters (14 sliders + 1 toggle) + 1 from SetExposure = 16
-            Assert.AreEqual(16, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 16 parameters (14 sliders + 2 toggles) + 1 from SetExposure = 17
+            Assert.AreEqual(17, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 15 messages (14 sliders + 1 toggle)
-            Assert.AreEqual(15, _mockTransmitter.SendCallCount);
+            // Force sends all 16 messages (14 sliders + 2 toggles)
+            Assert.AreEqual(16, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(15, secondCallCount); // 15 messages per Sync call (14 sliders + 1 toggle)
+            Assert.AreEqual(16, secondCallCount); // 16 messages per Sync call (14 sliders + 2 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 21 initial values (14 sliders + 7 toggles)
-            Assert.AreEqual(21, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 22 initial values (14 sliders + 8 toggles)
+            Assert.AreEqual(22, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 21 parameters (14 sliders + 7 toggles) + 1 from SetExposure = 22
-            Assert.AreEqual(22, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 22 parameters (14 sliders + 8 toggles) + 1 from SetExposure = 23
+            Assert.AreEqual(23, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(21, secondCallCount); // 21 messages per Sync call (14 sliders + 7 toggles)
+            Assert.AreEqual(22, secondCallCount); // 22 messages per Sync call (14 sliders + 8 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 24 initial values (14 sliders + 10 toggles)
-            Assert.AreEqual(24, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 25 initial values (14 sliders + 11 toggles)
+            Assert.AreEqual(25, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 24 parameters (14 sliders + 10 toggles) + 1 from SetExposure = 25
-            Assert.AreEqual(25, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 25 parameters (14 sliders + 11 toggles) + 1 from SetExposure = 26
+            Assert.AreEqual(26, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 24 messages (14 sliders + 10 toggles)
-            Assert.AreEqual(24, _mockTransmitter.SendCallCount);
+            // Force sends all 25 messages (14 sliders + 11 toggles)
+            Assert.AreEqual(25, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(24, secondCallCount); // 24 messages per Sync call (14 sliders + 10 toggles)
+            Assert.AreEqual(25, secondCallCount); // 25 messages per Sync call (14 sliders + 11 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 14 initial values
-            Assert.AreEqual(14, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 15 initial values (14 sliders + 1 toggle)
+            Assert.AreEqual(15, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 14 parameters + 1 from SetExposure = 15
-            Assert.AreEqual(15, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 15 parameters (14 sliders + 1 toggle) + 1 from SetExposure = 16
+            Assert.AreEqual(16, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,12 +138,13 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 14 messages
-            Assert.AreEqual(14, _mockTransmitter.SendCallCount);
+            // Force sends all 15 messages (14 sliders + 1 toggle)
+            Assert.AreEqual(15, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
+            // Last message is ShowUIInCamera toggle which has Bool type
             var message = _mockTransmitter.LastSentMessage.Value;
-            Assert.AreEqual(Argument.ValueType.Float32, message.Arguments[0].Type);
+            Assert.AreEqual(Argument.ValueType.Bool, message.Arguments[0].Type);
         }
         
         [Test]
@@ -162,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(14, secondCallCount); // 14 messages per Sync call
+            Assert.AreEqual(15, secondCallCount); // 15 messages per Sync call (14 sliders + 1 toggle)
         }
         
         [Test]
@@ -174,7 +175,8 @@ namespace VRCCamera.Tests.Unit
             // Assert
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             var message = _mockTransmitter.LastSentMessage.Value;
-            Assert.AreEqual("f", message.TypeTag.Value);
+            // Last message is ShowUIInCamera toggle, which has TypeTag "F" for false
+            Assert.AreEqual("F", message.TypeTag.Value);
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 27 initial values (14 sliders + 13 toggles)
-            Assert.AreEqual(27, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 28 initial values (14 sliders + 14 toggles)
+            Assert.AreEqual(28, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 27 parameters (14 sliders + 13 toggles) + 1 from SetExposure = 28
-            Assert.AreEqual(28, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 28 parameters (14 sliders + 14 toggles) + 1 from SetExposure = 29
+            Assert.AreEqual(29, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 27 messages (14 sliders + 13 toggles)
-            Assert.AreEqual(27, _mockTransmitter.SendCallCount);
+            // Force sends all 28 messages (14 sliders + 14 toggles)
+            Assert.AreEqual(28, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(27, secondCallCount); // 27 messages per Sync call (14 sliders + 13 toggles)
+            Assert.AreEqual(28, secondCallCount); // 28 messages per Sync call (14 sliders + 14 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 22 initial values (14 sliders + 8 toggles)
-            Assert.AreEqual(22, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 23 initial values (14 sliders + 9 toggles)
+            Assert.AreEqual(23, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 22 parameters (14 sliders + 8 toggles) + 1 from SetExposure = 23
-            Assert.AreEqual(23, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 23 parameters (14 sliders + 9 toggles) + 1 from SetExposure = 24
+            Assert.AreEqual(24, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 16 messages (14 sliders + 2 toggles)
-            Assert.AreEqual(16, _mockTransmitter.SendCallCount);
+            // Force sends all 23 messages (14 sliders + 9 toggles)
+            Assert.AreEqual(23, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(22, secondCallCount); // 22 messages per Sync call (14 sliders + 8 toggles)
+            Assert.AreEqual(23, secondCallCount); // 23 messages per Sync call (14 sliders + 9 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 18 initial values (14 sliders + 4 toggles)
-            Assert.AreEqual(18, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 19 initial values (14 sliders + 5 toggles)
+            Assert.AreEqual(19, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 18 parameters (14 sliders + 4 toggles) + 1 from SetExposure = 19
-            Assert.AreEqual(19, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 19 parameters (14 sliders + 5 toggles) + 1 from SetExposure = 20
+            Assert.AreEqual(20, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(18, secondCallCount); // 18 messages per Sync call (14 sliders + 4 toggles)
+            Assert.AreEqual(19, secondCallCount); // 19 messages per Sync call (14 sliders + 5 toggles)
         }
         
         [Test]
@@ -175,7 +175,7 @@ namespace VRCCamera.Tests.Unit
             // Assert
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             var message = _mockTransmitter.LastSentMessage.Value;
-            // Last message is ShowUIInCamera toggle, which has TypeTag "F" for false
+            // Last message is a toggle with default false, which has TypeTag "F"
             Assert.AreEqual("F", message.TypeTag.Value);
         }
         

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 26 initial values (14 sliders + 12 toggles)
-            Assert.AreEqual(26, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 27 initial values (14 sliders + 13 toggles)
+            Assert.AreEqual(27, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 26 parameters (14 sliders + 12 toggles) + 1 from SetExposure = 27
-            Assert.AreEqual(27, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 27 parameters (14 sliders + 13 toggles) + 1 from SetExposure = 28
+            Assert.AreEqual(28, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 26 messages (14 sliders + 12 toggles)
-            Assert.AreEqual(26, _mockTransmitter.SendCallCount);
+            // Force sends all 27 messages (14 sliders + 13 toggles)
+            Assert.AreEqual(27, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(26, secondCallCount); // 26 messages per Sync call (14 sliders + 12 toggles)
+            Assert.AreEqual(27, secondCallCount); // 27 messages per Sync call (14 sliders + 13 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 30 initial values (14 sliders + 16 toggles)
-            Assert.AreEqual(30, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 31 initial values (14 sliders + 17 toggles)
+            Assert.AreEqual(31, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 30 parameters (14 sliders + 16 toggles) + 1 from SetExposure = 31
-            Assert.AreEqual(31, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 31 parameters (14 sliders + 17 toggles) + 1 from SetExposure = 32
+            Assert.AreEqual(32, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 30 messages (14 sliders + 16 toggles)
-            Assert.AreEqual(30, _mockTransmitter.SendCallCount);
+            // Force sends all 31 messages (14 sliders + 17 toggles)
+            Assert.AreEqual(31, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(30, secondCallCount); // 30 messages per Sync call (14 sliders + 16 toggles)
+            Assert.AreEqual(31, secondCallCount); // 31 messages per Sync call (14 sliders + 17 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 16 initial values (14 sliders + 2 toggles)
-            Assert.AreEqual(16, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 17 initial values (14 sliders + 3 toggles)
+            Assert.AreEqual(17, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 16 parameters (14 sliders + 2 toggles) + 1 from SetExposure = 17
-            Assert.AreEqual(17, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 17 parameters (14 sliders + 3 toggles) + 1 from SetExposure = 18
+            Assert.AreEqual(18, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(16, secondCallCount); // 16 messages per Sync call (14 sliders + 2 toggles)
+            Assert.AreEqual(17, secondCallCount); // 17 messages per Sync call (14 sliders + 3 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 28 initial values (14 sliders + 14 toggles)
-            Assert.AreEqual(28, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 29 initial values (14 sliders + 15 toggles)
+            Assert.AreEqual(29, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 28 parameters (14 sliders + 14 toggles) + 1 from SetExposure = 29
-            Assert.AreEqual(29, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 29 parameters (14 sliders + 15 toggles) + 1 from SetExposure = 30
+            Assert.AreEqual(30, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 28 messages (14 sliders + 14 toggles)
-            Assert.AreEqual(28, _mockTransmitter.SendCallCount);
+            // Force sends all 29 messages (14 sliders + 15 toggles)
+            Assert.AreEqual(29, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(28, secondCallCount); // 28 messages per Sync call (14 sliders + 14 toggles)
+            Assert.AreEqual(29, secondCallCount); // 29 messages per Sync call (14 sliders + 15 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 29 initial values (14 sliders + 15 toggles)
-            Assert.AreEqual(29, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 30 initial values (14 sliders + 16 toggles)
+            Assert.AreEqual(30, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 29 parameters (14 sliders + 15 toggles) + 1 from SetExposure = 30
-            Assert.AreEqual(30, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 30 parameters (14 sliders + 16 toggles) + 1 from SetExposure = 31
+            Assert.AreEqual(31, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 29 messages (14 sliders + 15 toggles)
-            Assert.AreEqual(29, _mockTransmitter.SendCallCount);
+            // Force sends all 30 messages (14 sliders + 16 toggles)
+            Assert.AreEqual(30, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(29, secondCallCount); // 29 messages per Sync call (14 sliders + 15 toggles)
+            Assert.AreEqual(30, secondCallCount); // 30 messages per Sync call (14 sliders + 16 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 19 initial values (14 sliders + 5 toggles)
-            Assert.AreEqual(19, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 20 initial values (14 sliders + 6 toggles)
+            Assert.AreEqual(20, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 19 parameters (14 sliders + 5 toggles) + 1 from SetExposure = 20
-            Assert.AreEqual(20, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 20 parameters (14 sliders + 6 toggles) + 1 from SetExposure = 21
+            Assert.AreEqual(21, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(19, secondCallCount); // 19 messages per Sync call (14 sliders + 5 toggles)
+            Assert.AreEqual(20, secondCallCount); // 20 messages per Sync call (14 sliders + 6 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 25 initial values (14 sliders + 11 toggles)
-            Assert.AreEqual(25, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 26 initial values (14 sliders + 12 toggles)
+            Assert.AreEqual(26, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 25 parameters (14 sliders + 11 toggles) + 1 from SetExposure = 26
-            Assert.AreEqual(26, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 26 parameters (14 sliders + 12 toggles) + 1 from SetExposure = 27
+            Assert.AreEqual(27, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 25 messages (14 sliders + 11 toggles)
-            Assert.AreEqual(25, _mockTransmitter.SendCallCount);
+            // Force sends all 26 messages (14 sliders + 12 toggles)
+            Assert.AreEqual(26, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(25, secondCallCount); // 25 messages per Sync call (14 sliders + 11 toggles)
+            Assert.AreEqual(26, secondCallCount); // 26 messages per Sync call (14 sliders + 12 toggles)
         }
         
         [Test]

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 17 initial values (14 sliders + 3 toggles)
-            Assert.AreEqual(17, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 18 initial values (14 sliders + 4 toggles)
+            Assert.AreEqual(18, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 17 parameters (14 sliders + 3 toggles) + 1 from SetExposure = 18
-            Assert.AreEqual(18, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 18 parameters (14 sliders + 4 toggles) + 1 from SetExposure = 19
+            Assert.AreEqual(19, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(17, secondCallCount); // 17 messages per Sync call (14 sliders + 3 toggles)
+            Assert.AreEqual(18, secondCallCount); // 18 messages per Sync call (14 sliders + 4 toggles)
         }
         
         [Test]

--- a/Tests/Editor/ValueObjects/AutoLevelPitchToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/AutoLevelPitchToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class AutoLevelPitchToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new AutoLevelPitchToggle(true).Value);
+            Assert.IsFalse(new AutoLevelPitchToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new AutoLevelPitchToggle(true);
+            var b = new AutoLevelPitchToggle(true);
+            var c = new AutoLevelPitchToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new AutoLevelPitchToggle(true);
+            bool f = new AutoLevelPitchToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new AutoLevelPitchToggle(true).ToString());
+            Assert.AreEqual("False", new AutoLevelPitchToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/AutoLevelPitchToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/AutoLevelPitchToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f37caff66d5ed5e4880afe060f668944
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/AutoLevelRollToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/AutoLevelRollToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class AutoLevelRollToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new AutoLevelRollToggle(true).Value);
+            Assert.IsFalse(new AutoLevelRollToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new AutoLevelRollToggle(true);
+            var b = new AutoLevelRollToggle(true);
+            var c = new AutoLevelRollToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new AutoLevelRollToggle(true);
+            bool f = new AutoLevelRollToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new AutoLevelRollToggle(true).ToString());
+            Assert.AreEqual("False", new AutoLevelRollToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/AutoLevelRollToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/AutoLevelRollToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4d9fa0f9559d774bbc042c2fd86b968
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/CameraEarsToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/CameraEarsToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class CameraEarsToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new CameraEarsToggle(true).Value);
+            Assert.IsFalse(new CameraEarsToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new CameraEarsToggle(true);
+            var b = new CameraEarsToggle(true);
+            var c = new CameraEarsToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new CameraEarsToggle(true);
+            bool f = new CameraEarsToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new CameraEarsToggle(true).ToString());
+            Assert.AreEqual("False", new CameraEarsToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/CameraEarsToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/CameraEarsToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54f936ce5b85c4d41a306f76b1822881
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/DollyPathsStayVisibleToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/DollyPathsStayVisibleToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class DollyPathsStayVisibleToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new DollyPathsStayVisibleToggle(true).Value);
+            Assert.IsFalse(new DollyPathsStayVisibleToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new DollyPathsStayVisibleToggle(true);
+            var b = new DollyPathsStayVisibleToggle(true);
+            var c = new DollyPathsStayVisibleToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new DollyPathsStayVisibleToggle(true);
+            bool f = new DollyPathsStayVisibleToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new DollyPathsStayVisibleToggle(true).ToString());
+            Assert.AreEqual("False", new DollyPathsStayVisibleToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/DollyPathsStayVisibleToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/DollyPathsStayVisibleToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88e1340442fd1c64494a791a4c508298
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/EnvironmentToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/EnvironmentToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class EnvironmentToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new EnvironmentToggle(true).Value);
+            Assert.IsFalse(new EnvironmentToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new EnvironmentToggle(true);
+            var b = new EnvironmentToggle(true);
+            var c = new EnvironmentToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new EnvironmentToggle(true);
+            bool f = new EnvironmentToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new EnvironmentToggle(true).ToString());
+            Assert.AreEqual("False", new EnvironmentToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/EnvironmentToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/EnvironmentToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76783f2e4b0bc3d48836f205da9b94ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/FlyingToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/FlyingToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class FlyingToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new FlyingToggle(true).Value);
+            Assert.IsFalse(new FlyingToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new FlyingToggle(true);
+            var b = new FlyingToggle(true);
+            var c = new FlyingToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new FlyingToggle(true);
+            bool f = new FlyingToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new FlyingToggle(true).ToString());
+            Assert.AreEqual("False", new FlyingToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/FlyingToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/FlyingToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfa1df43d502d384ca7beedb9d836582
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/GreenScreenToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/GreenScreenToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class GreenScreenToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new GreenScreenToggle(true).Value);
+            Assert.IsFalse(new GreenScreenToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new GreenScreenToggle(true);
+            var b = new GreenScreenToggle(true);
+            var c = new GreenScreenToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new GreenScreenToggle(true);
+            bool f = new GreenScreenToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new GreenScreenToggle(true).ToString());
+            Assert.AreEqual("False", new GreenScreenToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/GreenScreenToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/GreenScreenToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2df2b23624d08448be357aead31bd79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/LocalPlayerToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/LocalPlayerToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class LocalPlayerToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new LocalPlayerToggle(true).Value);
+            Assert.IsFalse(new LocalPlayerToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new LocalPlayerToggle(true);
+            var b = new LocalPlayerToggle(true);
+            var c = new LocalPlayerToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new LocalPlayerToggle(true);
+            bool f = new LocalPlayerToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new LocalPlayerToggle(true).ToString());
+            Assert.AreEqual("False", new LocalPlayerToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/LocalPlayerToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/LocalPlayerToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9436812e388a23649877ba8329f4fa68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/LockToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/LockToggleUnitTests.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class LockToggleUnitTests
+    {
+        [Test]
+        public void Constructor_WithTrueValue_StoresTrue()
+        {
+            var toggle = new LockToggle(true);
+            Assert.IsTrue(toggle.Value);
+        }
+
+        [Test]
+        public void Constructor_WithFalseValue_StoresFalse()
+        {
+            var toggle = new LockToggle(false);
+            Assert.IsFalse(toggle.Value);
+        }
+
+        [Test]
+        public void Equals_WithSameValue_ReturnsTrue()
+        {
+            var t1 = new LockToggle(true);
+            var t2 = new LockToggle(true);
+            Assert.IsTrue(t1.Equals(t2));
+            Assert.IsTrue(t1 == t2);
+            Assert.IsFalse(t1 != t2);
+        }
+
+        [Test]
+        public void Equals_WithDifferentValue_ReturnsFalse()
+        {
+            var t1 = new LockToggle(true);
+            var t2 = new LockToggle(false);
+            Assert.IsFalse(t1.Equals(t2));
+            Assert.IsFalse(t1 == t2);
+            Assert.IsTrue(t1 != t2);
+        }
+
+        [Test]
+        public void GetHashCode_VariesByValue()
+        {
+            var t1 = new LockToggle(true);
+            var t2 = new LockToggle(false);
+            Assert.AreNotEqual(t1.GetHashCode(), t2.GetHashCode());
+        }
+
+        [Test]
+        public void Implicit_ToBool_ReturnsUnderlyingValue()
+        {
+            bool v1 = new LockToggle(true);
+            bool v2 = new LockToggle(false);
+            Assert.IsTrue(v1);
+            Assert.IsFalse(v2);
+        }
+
+        [Test]
+        public void ToString_ReflectsValue()
+        {
+            Assert.AreEqual("True", new LockToggle(true).ToString());
+            Assert.AreEqual("False", new LockToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/LockToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/LockToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e9691c91462c234b9369ade26b1ab90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/LookAtMeToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/LookAtMeToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class LookAtMeToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new LookAtMeToggle(true).Value);
+            Assert.IsFalse(new LookAtMeToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new LookAtMeToggle(true);
+            var b = new LookAtMeToggle(true);
+            var c = new LookAtMeToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new LookAtMeToggle(true);
+            bool f = new LookAtMeToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new LookAtMeToggle(true).ToString());
+            Assert.AreEqual("False", new LookAtMeToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/LookAtMeToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/LookAtMeToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c8144b7e6d9c334f935d397761d662d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/OrientationIsLandscapeToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/OrientationIsLandscapeToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class OrientationIsLandscapeToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new OrientationIsLandscapeToggle(true).Value);
+            Assert.IsFalse(new OrientationIsLandscapeToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new OrientationIsLandscapeToggle(true);
+            var b = new OrientationIsLandscapeToggle(true);
+            var c = new OrientationIsLandscapeToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new OrientationIsLandscapeToggle(true);
+            bool f = new OrientationIsLandscapeToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new OrientationIsLandscapeToggle(true).ToString());
+            Assert.AreEqual("False", new OrientationIsLandscapeToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/OrientationIsLandscapeToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/OrientationIsLandscapeToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf88c72df7f8126488fa93076fbbb3aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/RemotePlayerToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/RemotePlayerToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class RemotePlayerToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new RemotePlayerToggle(true).Value);
+            Assert.IsFalse(new RemotePlayerToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new RemotePlayerToggle(true);
+            var b = new RemotePlayerToggle(true);
+            var c = new RemotePlayerToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new RemotePlayerToggle(true);
+            bool f = new RemotePlayerToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new RemotePlayerToggle(true).ToString());
+            Assert.AreEqual("False", new RemotePlayerToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/RemotePlayerToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/RemotePlayerToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa5bc600ca259c44e81fb763e0cafb86
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/RollWhileFlyingToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/RollWhileFlyingToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class RollWhileFlyingToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new RollWhileFlyingToggle(true).Value);
+            Assert.IsFalse(new RollWhileFlyingToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new RollWhileFlyingToggle(true);
+            var b = new RollWhileFlyingToggle(true);
+            var c = new RollWhileFlyingToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new RollWhileFlyingToggle(true);
+            bool f = new RollWhileFlyingToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new RollWhileFlyingToggle(true).ToString());
+            Assert.AreEqual("False", new RollWhileFlyingToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/RollWhileFlyingToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/RollWhileFlyingToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85eea7105b98b1148b93b9af73237206
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/ShowFocusToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/ShowFocusToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class ShowFocusToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new ShowFocusToggle(true).Value);
+            Assert.IsFalse(new ShowFocusToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new ShowFocusToggle(true);
+            var b = new ShowFocusToggle(true);
+            var c = new ShowFocusToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new ShowFocusToggle(true);
+            bool f = new ShowFocusToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new ShowFocusToggle(true).ToString());
+            Assert.AreEqual("False", new ShowFocusToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/ShowFocusToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/ShowFocusToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7d1681d6dccf6e47b5045e40d29e7e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/ShowUIInCameraToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/ShowUIInCameraToggleUnitTests.cs
@@ -1,0 +1,126 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class ShowUIInCameraToggleUnitTests
+    {
+        [Test]
+        public void Constructor_WithTrueValue_StoresTrue()
+        {
+            // Act
+            var toggle = new ShowUIInCameraToggle(true);
+            
+            // Assert
+            Assert.IsTrue(toggle.Value);
+        }
+        
+        [Test]
+        public void Constructor_WithFalseValue_StoresFalse()
+        {
+            // Act
+            var toggle = new ShowUIInCameraToggle(false);
+            
+            // Assert
+            Assert.IsFalse(toggle.Value);
+        }
+        
+        [Test]
+        public void Equals_WithSameValue_ReturnsTrue()
+        {
+            // Arrange
+            var toggle1 = new ShowUIInCameraToggle(true);
+            var toggle2 = new ShowUIInCameraToggle(true);
+            
+            // Act & Assert
+            Assert.IsTrue(toggle1.Equals(toggle2));
+            Assert.IsTrue(toggle1 == toggle2);
+            Assert.IsFalse(toggle1 != toggle2);
+        }
+        
+        [Test]
+        public void Equals_WithDifferentValue_ReturnsFalse()
+        {
+            // Arrange
+            var toggle1 = new ShowUIInCameraToggle(true);
+            var toggle2 = new ShowUIInCameraToggle(false);
+            
+            // Act & Assert
+            Assert.IsFalse(toggle1.Equals(toggle2));
+            Assert.IsFalse(toggle1 == toggle2);
+            Assert.IsTrue(toggle1 != toggle2);
+        }
+        
+        [Test]
+        public void GetHashCode_WithSameValue_ReturnsSameHash()
+        {
+            // Arrange
+            var toggle1 = new ShowUIInCameraToggle(true);
+            var toggle2 = new ShowUIInCameraToggle(true);
+            
+            // Act & Assert
+            Assert.AreEqual(toggle1.GetHashCode(), toggle2.GetHashCode());
+        }
+        
+        [Test]
+        public void GetHashCode_WithDifferentValue_ReturnsDifferentHash()
+        {
+            // Arrange
+            var toggle1 = new ShowUIInCameraToggle(true);
+            var toggle2 = new ShowUIInCameraToggle(false);
+            
+            // Act & Assert
+            Assert.AreNotEqual(toggle1.GetHashCode(), toggle2.GetHashCode());
+        }
+        
+        [Test]
+        public void ImplicitOperator_ToBool_ReturnsCorrectValue()
+        {
+            // Arrange
+            var toggleTrue = new ShowUIInCameraToggle(true);
+            var toggleFalse = new ShowUIInCameraToggle(false);
+            
+            // Act
+            bool valueTrue = toggleTrue;
+            bool valueFalse = toggleFalse;
+            
+            // Assert
+            Assert.IsTrue(valueTrue);
+            Assert.IsFalse(valueFalse);
+        }
+        
+        [Test]
+        public void ToString_ReturnsCorrectStringRepresentation()
+        {
+            // Arrange
+            var toggleTrue = new ShowUIInCameraToggle(true);
+            var toggleFalse = new ShowUIInCameraToggle(false);
+            
+            // Act & Assert
+            Assert.AreEqual("True", toggleTrue.ToString());
+            Assert.AreEqual("False", toggleFalse.ToString());
+        }
+        
+        [Test]
+        public void Equals_WithNullObject_ReturnsFalse()
+        {
+            // Arrange
+            var toggle = new ShowUIInCameraToggle(true);
+            
+            // Act & Assert
+            Assert.IsFalse(toggle.Equals(null));
+        }
+        
+        [Test]
+        public void Equals_WithDifferentType_ReturnsFalse()
+        {
+            // Arrange
+            var toggle = new ShowUIInCameraToggle(true);
+            
+            // Act & Assert
+            Assert.IsFalse(toggle.Equals("true"));
+            Assert.IsFalse(toggle.Equals(1));
+        }
+    }
+}

--- a/Tests/Editor/ValueObjects/ShowUIInCameraToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/ShowUIInCameraToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67b06bc8f5a920244a1d4ff7d879a505
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/SmoothMovementToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/SmoothMovementToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class SmoothMovementToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new SmoothMovementToggle(true).Value);
+            Assert.IsFalse(new SmoothMovementToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new SmoothMovementToggle(true);
+            var b = new SmoothMovementToggle(true);
+            var c = new SmoothMovementToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new SmoothMovementToggle(true);
+            bool f = new SmoothMovementToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new SmoothMovementToggle(true).ToString());
+            Assert.AreEqual("False", new SmoothMovementToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/SmoothMovementToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/SmoothMovementToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8827d2333d5a8af41be3751dc6e1df4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/StreamingToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/StreamingToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class StreamingToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new StreamingToggle(true).Value);
+            Assert.IsFalse(new StreamingToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new StreamingToggle(true);
+            var b = new StreamingToggle(true);
+            var c = new StreamingToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new StreamingToggle(true);
+            bool f = new StreamingToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new StreamingToggle(true).ToString());
+            Assert.AreEqual("False", new StreamingToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/StreamingToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/StreamingToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 376f5b1c05952fd4d961d7978a2cef9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ValueObjects/TriggerTakesPhotosToggleUnitTests.cs
+++ b/Tests/Editor/ValueObjects/TriggerTakesPhotosToggleUnitTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Parameters;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class TriggerTakesPhotosToggleUnitTests
+    {
+        [Test]
+        public void Constructor_StoresValue()
+        {
+            Assert.IsTrue(new TriggerTakesPhotosToggle(true).Value);
+            Assert.IsFalse(new TriggerTakesPhotosToggle(false).Value);
+        }
+
+        [Test]
+        public void Equality_WorksByValue()
+        {
+            var a = new TriggerTakesPhotosToggle(true);
+            var b = new TriggerTakesPhotosToggle(true);
+            var c = new TriggerTakesPhotosToggle(false);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+
+        [Test]
+        public void ImplicitBool_And_ToString()
+        {
+            bool t = new TriggerTakesPhotosToggle(true);
+            bool f = new TriggerTakesPhotosToggle(false);
+            Assert.IsTrue(t);
+            Assert.IsFalse(f);
+            Assert.AreEqual("True", new TriggerTakesPhotosToggle(true).ToString());
+            Assert.AreEqual("False", new TriggerTakesPhotosToggle(false).ToString());
+        }
+    }
+}
+

--- a/Tests/Editor/ValueObjects/TriggerTakesPhotosToggleUnitTests.cs.meta
+++ b/Tests/Editor/ValueObjects/TriggerTakesPhotosToggleUnitTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39414f8ae1f638f47b87a2cba4beef6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
  ## Summary

  Implements all 18 documented boolean toggle endpoints for the VRChat user camera via OSC, following existing slider/toggle patterns. Adds value objects, converters, runtime wiring, inspector controls, and supporting tests.

  ## Changes

  - Value objects in Scripts/Runtime/Parameters/
      - ShowUIInCamera, Lock, LocalPlayer, RemotePlayer, Environment, GreenScreen
      - SmoothMovement, LookAtMe, AutoLevelRoll, AutoLevelPitch
      - Flying, TriggerTakesPhotos, DollyPathsStayVisible, CameraEars
      - ShowFocus, Streaming, RollWhileFlying, OrientationIsLandscape
  - OSC converters in Scripts/Runtime/OSC/
      - IOSCMessageConverter<T> per toggle, mapped to /usercamera/...
      - Sends Bool; accepts Bool/Int32/Float32 for compatibility
  - Runtime wiring
      - VRCCamera: ReactiveProperty<TToggle> + SetXxx(...) for each toggle
      - VRCCameraSynchronizer: subscribe on change, include in Sync(), unsubscribe in Dispose()
  - Inspector
      - Toggles: Lock, Smooth Movement, Look At Me, Auto Level Roll/Pitch, Flying, Trigger Takes Photos, Dolly Paths Stay Visible,
  Camera Ears, Show Focus, Streaming, Roll While Flying, Orientation Is Landscape
      - Mask: Local User → Remote User → World → Green Screen (Color indented) → UI
      - Labels updated to “Local User”, “Remote User”, “World”, “UI”

  ## Acceptance

  - [x] All 18 documented toggles implemented with value objects
  - [x] Converters mapped to /usercamera/... endpoints
  - [x] Reactive wiring: change-driven sending, Sync(), cleanup in Dispose()
  - [x] Inspector exposes toggles with requested labels and order
  - [x] Unit tests updated; synchronizer counts reflect 32 messages per Sync
  - [x] No performance regressions; follows existing conventions

  ## Notes

  - Endpoints strictly follow VRChat 2025.3.3 Open Beta documentation.
  - Some toggles’ visible effects may depend on VRChat build/state even if OSC receives values.

  ## Links

  - Closes #7
  - Docs: https://docs.vrchat.com/docs/vrchat-202533-openbeta#osc-camera-endpoints
  - Related:
    - #3 (Sliders)
    - #5 (ReactiveProperty system)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added many camera toggles (UI-in-camera, lock, local/remote, environment, green screen, smooth movement, look-at-me, auto-level roll/pitch, flying, trigger-to-photo, dolly paths, camera ears, show focus, streaming, roll-while-flying, orientation) and a Mask color picker (HSV).

- **Improvements**
  - Inspector reorganized into Toggles and Mask sections; inspector shows read-only camera parameters when available and keeps settings synced at runtime.

- **Tests**
  - Extensive unit tests for value objects and OSC converters for all new toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->