### PR TITLE
Implement OSC Camera Mode

### DIFF
--- a/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraSynchronizerComponentEditor.cs
@@ -39,6 +39,7 @@ namespace VRCCamera.Editor
         private SerializedProperty _streaming;
         private SerializedProperty _rollWhileFlying;
         private SerializedProperty _orientation;
+        private SerializedProperty _mode;
 
         private void OnEnable()
         {
@@ -74,6 +75,7 @@ namespace VRCCamera.Editor
             _streaming = serializedObject.FindProperty("streaming");
             _rollWhileFlying = serializedObject.FindProperty("rollWhileFlying");
             _orientation = serializedObject.FindProperty("orientation");
+            _mode = serializedObject.FindProperty("mode");
         }
 
         public override void OnInspectorGUI()
@@ -123,6 +125,27 @@ namespace VRCCamera.Editor
             EditorGUILayout.LabelField("General", EditorStyles.boldLabel);
             using (new EditorGUI.IndentLevelScope())
             {
+                // Mode: custom ordering/labels while preserving OSC indices
+                var modeOrder = new Mode[]
+                {
+                    Mode.Off,       // 0
+                    Mode.Photo,     // 1
+                    Mode.Multilayer,// 4
+                    Mode.Stream,    // 2
+                    Mode.Print,     // 5
+                    Mode.Emoji,     // 3
+                    Mode.Drone      // 6
+                };
+                var modeLabels = new[] { "Off", "Local Photo", "Multi Layer", "Stream", "Print", "Emoji", "Drone" };
+                var currentModeValue = _mode.intValue;
+                var currentIndex = System.Array.IndexOf(modeOrder, (Mode)currentModeValue);
+                if (currentIndex < 0) currentIndex = 0;
+                EditorGUI.BeginChangeCheck();
+                var newIndex = EditorGUILayout.Popup("Camera Mode", currentIndex, modeLabels);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    _mode.intValue = (int)modeOrder[newIndex];
+                }
                 EditorGUILayout.PropertyField(_orientation, new GUIContent("Orientation"));
                 EditorGUILayout.Slider(_exposure, Exposure.MinValue, Exposure.MaxValue, "Exposure");
                 // Display camera-driven parameters as read-only

--- a/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
+++ b/Scripts/Runtime/Component/VRCCameraSynchronizerComponent.cs
@@ -42,6 +42,7 @@ namespace VRCCamera
         [SerializeField] private bool streaming = false;
         [SerializeField] private bool rollWhileFlying = false;
         [SerializeField] private Orientation orientation = Orientation.Landscape;
+        [SerializeField] private Mode mode = Mode.Photo;
 
         private VRCCamera _vrcCamera;
         private VRCCameraSynchronizer _synchronizer;
@@ -92,6 +93,7 @@ namespace VRCCamera
                 _vrcCamera.SetStreaming(new StreamingToggle(streaming));
                 _vrcCamera.SetRollWhileFlying(new RollWhileFlyingToggle(rollWhileFlying));
                 _vrcCamera.SetOrientation(orientation);
+                _vrcCamera.SetMode(mode);
                 
                 transmitter = new OSCJackTransmitter(destination, port);
                 _synchronizer = new VRCCameraSynchronizer(transmitter, _vrcCamera);
@@ -168,6 +170,7 @@ namespace VRCCamera
             _vrcCamera.SetStreaming(new StreamingToggle(streaming));
             _vrcCamera.SetRollWhileFlying(new RollWhileFlyingToggle(rollWhileFlying));
             _vrcCamera.SetOrientation(orientation);
+            _vrcCamera.SetMode(mode);
         }
     }
 }

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -40,6 +40,9 @@ namespace VRCCamera
         public ReactiveProperty<RollWhileFlyingToggle> RollWhileFlying { get; }
         public ReactiveProperty<Orientation> Orientation { get; }
         public ReactiveProperty<ItemsToggle> Items { get; }
+        /// <summary>
+        /// Current camera <see cref="Mode"/>; changes are published over OSC.
+        /// </summary>
         public ReactiveProperty<Mode> Mode { get; }
 
         public VRCCamera(Camera camera)
@@ -321,7 +324,7 @@ namespace VRCCamera
         }
         
         /// <summary>
-        /// Sets Mode value reactively
+        /// Sets <see cref="Mode"/> value reactively
         /// </summary>
         public void SetMode(Mode mode)
         {

--- a/Scripts/Runtime/Modules/VRCCamera.cs
+++ b/Scripts/Runtime/Modules/VRCCamera.cs
@@ -40,6 +40,7 @@ namespace VRCCamera
         public ReactiveProperty<RollWhileFlyingToggle> RollWhileFlying { get; }
         public ReactiveProperty<Orientation> Orientation { get; }
         public ReactiveProperty<ItemsToggle> Items { get; }
+        public ReactiveProperty<Mode> Mode { get; }
 
         public VRCCamera(Camera camera)
         {
@@ -79,6 +80,7 @@ namespace VRCCamera
             Streaming = new ReactiveProperty<StreamingToggle>(new StreamingToggle(false));
             RollWhileFlying = new ReactiveProperty<RollWhileFlyingToggle>(new RollWhileFlyingToggle(false));
             Orientation = new ReactiveProperty<Orientation>(Parameters.Orientation.Landscape);
+            Mode = new ReactiveProperty<Mode>(Parameters.Mode.Photo);
             // Items has no OSC endpoint; keep as display-only (default true)
             Items = new ReactiveProperty<ItemsToggle>(new ItemsToggle(true));
         }
@@ -319,6 +321,14 @@ namespace VRCCamera
         }
         
         /// <summary>
+        /// Sets Mode value reactively
+        /// </summary>
+        public void SetMode(Mode mode)
+        {
+            Mode.SetValue(mode);
+        }
+        
+        /// <summary>
         /// Disposes the VRCCamera and clears all event subscriptions
         /// </summary>
         public void Dispose()
@@ -355,6 +365,7 @@ namespace VRCCamera
             Streaming?.ClearSubscriptions();
             RollWhileFlying?.ClearSubscriptions();
             Orientation?.ClearSubscriptions();
+            Mode?.ClearSubscriptions();
             Items?.ClearSubscriptions();
         }
     }

--- a/Scripts/Runtime/OSC/ModeConverter.cs
+++ b/Scripts/Runtime/OSC/ModeConverter.cs
@@ -1,0 +1,59 @@
+using OSC;
+using Parameters;
+
+namespace VRCCamera
+{
+    public class ModeConverter : IOSCMessageConverter<Mode>
+    {
+        public Mode FromOSCMessage(Message message)
+        {
+            if (message.Address != OSCCameraEndpoints.Mode)
+            {
+                return Mode.Off;
+            }
+
+            if (message.Arguments is not { Length: 1 })
+            {
+                return Mode.Off;
+            }
+
+            var arg = message.Arguments[0];
+            if (arg.Type == Argument.ValueType.Int32)
+            {
+                var value = arg.AsInt32();
+                return value switch
+                {
+                    0 => Mode.Off,
+                    1 => Mode.Photo,
+                    2 => Mode.Stream,
+                    3 => Mode.Emoji,
+                    4 => Mode.Multilayer,
+                    5 => Mode.Print,
+                    6 => Mode.Drone,
+                    _ => Mode.Off
+                };
+            }
+
+            // Unsupported type
+            return Mode.Off;
+        }
+
+        public Message ToOSCMessage(Mode mode)
+        {
+            var intValue = mode switch
+            {
+                Mode.Off => 0,
+                Mode.Photo => 1,
+                Mode.Stream => 2,
+                Mode.Emoji => 3,
+                Mode.Multilayer => 4,
+                Mode.Print => 5,
+                Mode.Drone => 6,
+                _ => 0
+            };
+
+            return new Message(OSCCameraEndpoints.Mode, new[] { new Argument(intValue) });
+        }
+    }
+}
+

--- a/Scripts/Runtime/OSC/ModeConverter.cs
+++ b/Scripts/Runtime/OSC/ModeConverter.cs
@@ -3,8 +3,16 @@ using Parameters;
 
 namespace VRCCamera
 {
+    /// <summary>
+    /// Converts OSC messages to/from <see cref="Mode"/> for the /usercamera/Mode endpoint.
+    /// </summary>
     public class ModeConverter : IOSCMessageConverter<Mode>
     {
+        /// <summary>
+        /// Parses a <see cref="Message"/> into a <see cref="Mode"/> value.
+        /// Accepts Int32 indices (0-6). Float32 values are also accepted by truncation for robustness.
+        /// Returns <see cref="Mode.Off"/> on invalid input.
+        /// </summary>
         public Mode FromOSCMessage(Message message)
         {
             if (message.Address != OSCCameraEndpoints.Mode)
@@ -18,26 +26,35 @@ namespace VRCCamera
             }
 
             var arg = message.Arguments[0];
-            if (arg.Type == Argument.ValueType.Int32)
+            int value;
+            switch (arg.Type)
             {
-                var value = arg.AsInt32();
-                return value switch
-                {
-                    0 => Mode.Off,
-                    1 => Mode.Photo,
-                    2 => Mode.Stream,
-                    3 => Mode.Emoji,
-                    4 => Mode.Multilayer,
-                    5 => Mode.Print,
-                    6 => Mode.Drone,
-                    _ => Mode.Off
-                };
+                case Argument.ValueType.Int32:
+                    value = arg.AsInt32();
+                    break;
+                case Argument.ValueType.Float32:
+                    value = (int)arg.AsFloat32();
+                    break;
+                default:
+                    return Mode.Off;
             }
 
-            // Unsupported type
-            return Mode.Off;
+            return value switch
+            {
+                0 => Mode.Off,
+                1 => Mode.Photo,
+                2 => Mode.Stream,
+                3 => Mode.Emoji,
+                4 => Mode.Multilayer,
+                5 => Mode.Print,
+                6 => Mode.Drone,
+                _ => Mode.Off
+            };
         }
 
+        /// <summary>
+        /// Builds a <see cref="Message"/> containing the OSC index for the given <see cref="Mode"/>.
+        /// </summary>
         public Message ToOSCMessage(Mode mode)
         {
             var intValue = mode switch
@@ -56,4 +73,3 @@ namespace VRCCamera
         }
     }
 }
-

--- a/Scripts/Runtime/OSC/ModeConverter.cs.meta
+++ b/Scripts/Runtime/OSC/ModeConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5f2c2f6b2cde4c0eac0e7b0bce3a4d1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
+++ b/Scripts/Runtime/OSC/VRCCameraSynchronizer.cs
@@ -39,6 +39,7 @@ namespace VRCCamera
         private readonly ShowFocusToggleConverter _showFocusToggleConverter = new();
         private readonly StreamingToggleConverter _streamingToggleConverter = new();
         private readonly RollWhileFlyingToggleConverter _rollWhileFlyingToggleConverter = new();
+        private readonly ModeConverter _modeConverter = new();
         private bool _disposed = false;
 
         public VRCCameraSynchronizer(IOSCTransmitter transmitter, VRCCamera vrcCamera)
@@ -73,6 +74,7 @@ namespace VRCCamera
             _vrcCamera.Flying.OnValueChanged += OnFlyingChanged;
             _vrcCamera.TriggerTakesPhotos.OnValueChanged += OnTriggerTakesPhotosChanged;
             _vrcCamera.DollyPathsStayVisible.OnValueChanged += OnDollyPathsStayVisibleChanged;
+            _vrcCamera.Mode.OnValueChanged += OnModeChanged;
             _vrcCamera.CameraEars.OnValueChanged += OnCameraEarsChanged;
             _vrcCamera.ShowFocus.OnValueChanged += OnShowFocusChanged;
             _vrcCamera.Streaming.OnValueChanged += OnStreamingChanged;
@@ -377,6 +379,7 @@ namespace VRCCamera
             _transmitter.Send(_showFocusToggleConverter.ToOSCMessage(_vrcCamera.ShowFocus.Value));
             _transmitter.Send(_streamingToggleConverter.ToOSCMessage(_vrcCamera.Streaming.Value));
             _transmitter.Send(_rollWhileFlyingToggleConverter.ToOSCMessage(_vrcCamera.RollWhileFlying.Value));
+            _transmitter.Send(_modeConverter.ToOSCMessage(_vrcCamera.Mode.Value));
             var isLandscape = _vrcCamera.Orientation.Value == Parameters.Orientation.Landscape;
             _transmitter.Send(new OSC.Message(OSCCameraEndpoints.OrientationIsLandscape, new[] { new OSC.Argument(isLandscape) }));
         }
@@ -420,6 +423,7 @@ namespace VRCCamera
                 _vrcCamera.Streaming.OnValueChanged -= OnStreamingChanged;
                 _vrcCamera.RollWhileFlying.OnValueChanged -= OnRollWhileFlyingChanged;
                 _vrcCamera.Orientation.OnValueChanged -= OnOrientationChanged;
+                _vrcCamera.Mode.OnValueChanged -= OnModeChanged;
             }
 
             _transmitter?.Dispose();
@@ -435,6 +439,14 @@ namespace VRCCamera
         {
             if (_disposed) throw new ObjectDisposedException(nameof(VRCCameraSynchronizer));
             _transmitter.Send(new Message(address, Array.Empty<Argument>()));
+        }
+
+        private void OnModeChanged(Mode mode)
+        {
+            if (_disposed) return;
+
+            var message = _modeConverter.ToOSCMessage(mode);
+            _transmitter.Send(message);
         }
     }
 }

--- a/Scripts/Runtime/Parameters/Mode.cs
+++ b/Scripts/Runtime/Parameters/Mode.cs
@@ -1,0 +1,17 @@
+namespace Parameters
+{
+    /// <summary>
+    /// User camera mode for VRChat OSC control
+    /// </summary>
+    public enum Mode
+    {
+        Off = 0,
+        Photo = 1,
+        Stream = 2,
+        Emoji = 3,
+        Multilayer = 4,
+        Print = 5,
+        Drone = 6
+    }
+}
+

--- a/Scripts/Runtime/Parameters/Mode.cs
+++ b/Scripts/Runtime/Parameters/Mode.cs
@@ -1,17 +1,24 @@
 namespace Parameters
 {
     /// <summary>
-    /// User camera mode for VRChat OSC control
+    /// User camera mode for VRChat OSC control.
+    /// Values map to /usercamera/Mode indices 0–6.
     /// </summary>
     public enum Mode
     {
+        /// <summary>0: Camera is Off</summary>
         Off = 0,
+        /// <summary>1: Photo mode</summary>
         Photo = 1,
+        /// <summary>2: Stream mode</summary>
         Stream = 2,
+        /// <summary>3: Emoji mode</summary>
         Emoji = 3,
+        /// <summary>4: Multilayer mode</summary>
         Multilayer = 4,
+        /// <summary>5: Print mode</summary>
         Print = 5,
+        /// <summary>6: Drone mode</summary>
         Drone = 6
     }
 }
-

--- a/Scripts/Runtime/Parameters/Mode.cs.meta
+++ b/Scripts/Runtime/Parameters/Mode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e38569515614085458070c0e2129470e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/OSC/ModeConverterUnitTests.cs
+++ b/Tests/Editor/OSC/ModeConverterUnitTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using Parameters;
+using OSC;
+
+namespace VRCCamera.Tests.Unit
+{
+    [TestFixture]
+    public class ModeConverterUnitTests
+    {
+        private ModeConverter _converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _converter = new ModeConverter();
+        }
+
+        [Test]
+        public void ToOSCMessage_BuildsMessage_WithInt32()
+        {
+            var msg = _converter.ToOSCMessage(Mode.Stream);
+            Assert.AreEqual(OSCCameraEndpoints.Mode.Value, msg.Address.Value);
+            Assert.AreEqual(1, msg.Arguments.Length);
+            Assert.AreEqual(2, msg.Arguments[0].AsInt32());
+            Assert.AreEqual(Argument.ValueType.Int32, msg.Arguments[0].Type);
+            Assert.AreEqual("i", msg.TypeTag.Value);
+        }
+
+        [Test]
+        public void FromOSCMessage_WithValidInt_ReturnsEnum()
+        {
+            Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(0) })));
+            Assert.AreEqual(Mode.Photo, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(1) })));
+            Assert.AreEqual(Mode.Stream, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(2) })));
+            Assert.AreEqual(Mode.Emoji, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(3) })));
+            Assert.AreEqual(Mode.Multilayer, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(4) })));
+            Assert.AreEqual(Mode.Print, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(5) })));
+            Assert.AreEqual(Mode.Drone, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(6) })));
+        }
+
+        [Test]
+        public void FromOSCMessage_InvalidInputs_ReturnsOff()
+        {
+            Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(2) })));
+            Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, System.Array.Empty<Argument>())));
+            Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(2.0f) })));
+            Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(999) })));
+        }
+    }
+}
+

--- a/Tests/Editor/OSC/ModeConverterUnitTests.cs
+++ b/Tests/Editor/OSC/ModeConverterUnitTests.cs
@@ -39,13 +39,18 @@ namespace VRCCamera.Tests.Unit
         }
 
         [Test]
+        public void FromOSCMessage_WithFloatIndex_TruncatesToEnum()
+        {
+            Assert.AreEqual(Mode.Photo, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(1.9f) })));
+            Assert.AreEqual(Mode.Stream, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(2.0f) })));
+        }
+
+        [Test]
         public void FromOSCMessage_InvalidInputs_ReturnsOff()
         {
             Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(new Address("/other"), new[] { new Argument(2) })));
             Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, System.Array.Empty<Argument>())));
-            Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(2.0f) })));
             Assert.AreEqual(Mode.Off, _converter.FromOSCMessage(new Message(OSCCameraEndpoints.Mode, new[] { new Argument(999) })));
         }
     }
 }
-

--- a/Tests/Editor/OSC/ModeConverterUnitTests.cs.meta
+++ b/Tests/Editor/OSC/ModeConverterUnitTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9e42fdf0b6e34b018a9b4e3f4cb27c01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
+++ b/Tests/Editor/OSC/VRCCameraSynchronizerUnitTests.cs
@@ -101,8 +101,8 @@ namespace VRCCamera.Tests.Unit
             // Act
             var synchronizer = new VRCCameraSynchronizer(mockTransmitter, vrcCamera);
             
-            // Assert - Constructor should send all 32 initial values (14 sliders + 18 toggles)
-            Assert.AreEqual(32, mockTransmitter.SendCallCount);
+            // Assert - Constructor should send all 33 initial values (14 sliders + 18 toggles + 1 mode)
+            Assert.AreEqual(33, mockTransmitter.SendCallCount);
             
             // Cleanup
             synchronizer.Dispose();
@@ -122,8 +122,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Sync now force sends all 32 parameters (14 sliders + 18 toggles) + 1 from SetExposure = 33
-            Assert.AreEqual(33, _mockTransmitter.SendCallCount);
+            // Sync now force sends all 33 parameters (14 sliders + 18 toggles + 1 mode) + 1 from SetExposure = 34
+            Assert.AreEqual(34, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
         }
         
@@ -138,8 +138,8 @@ namespace VRCCamera.Tests.Unit
             _synchronizer.Sync();
             
             // Assert
-            // Force sends all 32 messages (14 sliders + 18 toggles)
-            Assert.AreEqual(32, _mockTransmitter.SendCallCount);
+            // Force sends all 33 messages (14 sliders + 18 toggles + 1 mode)
+            Assert.AreEqual(33, _mockTransmitter.SendCallCount);
             Assert.IsNotNull(_mockTransmitter.LastSentMessage);
             
             // Last message is ShowUIInCamera toggle which has Bool type
@@ -163,7 +163,7 @@ namespace VRCCamera.Tests.Unit
             var secondCallCount = _mockTransmitter.SendCallCount;
             
             // Assert
-            Assert.AreEqual(32, secondCallCount); // 32 messages per Sync call (14 sliders + 18 toggles)
+            Assert.AreEqual(33, secondCallCount); // 33 messages per Sync call (14 sliders + 18 toggles + 1 mode)
         }
         
         [Test]


### PR DESCRIPTION
## Summary

  Adds support for the documented user camera Mode via OSC. Introduces a Mode parameter and converter, wires through runtime sync, and exposes a “Camera Mode” dropdown in the Inspector with custom labels/order while preserving OSC indices.

  ## Changes

  - Runtime
      - Parameters.Mode enum mapping VRChat indices: 0 Off, 1 Photo, 2 Stream, 3 Emoji, 4 Multilayer, 5 Print, 6 Drone
      - VRCCamera.SetMode(Mode) and reactive Mode value; default Photo
      - VRCCameraSynchronizer publishes /usercamera/Mode (Int32 0–6) on change and in initial sync
      - ModeConverter converts between Mode and Int32 for /usercamera/Mode
  - Component + Inspector
      - VRCCameraSynchronizerComponent serialized mode field; applied in OnEnable and FixedUpdate
      - Inspector “General” section:
          - Dropdown: “Camera Mode” with labels “Off”, “Local Photo”, “Multi Layer”, “Stream”, “Print”, “Emoji”,
  “Drone” (OSC indices preserved)
  - Tests
      - ModeConverterUnitTests:
          - Verifies /usercamera/Mode endpoint and Int32 type tag
          - Verifies 0–6 mapping and fallback to Off for invalid inputs

  ## Acceptance

  - [x] Mode available via public API and serialized on the component
  - [x] Mode sends exactly one message to /usercamera/Mode with a single Int32 argument on change and in initial sync
  - [x] Disposal guard in place (no sends after Dispose())
  - [x] Inspector dropdown available with labels/order: Off, Local Photo, Multi Layer, Stream, Print, Emoji, Drone; OSC
  indices preserved
  - [x] Unit tests added and passing

  ## Notes

  - Mode uses Int32 index mapping per docs; UI ordering/labels do not change OSC indices
  - No other endpoints or behaviors changed

  ## Links

  - Closes #13
  - Docs: https://docs.vrchat.com/docs/vrchat-202533-openbeta#osc-camera-endpoints
  - Related:
      - #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Camera Mode support with a selectable inspector dropdown (Off, Local Photo, Multi Layer, Stream, Print, Emoji, Drone).
  - Camera now applies and maintains the selected mode during play.
  - Mode changes are synchronized over OSC for external control/integration.

- **Tests**
  - Added unit tests for OSC mode conversion and error handling; updated synchronizer tests to include the new mode.

- **Chores**
  - Added metadata files for new assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->