### PR TITLE
Release VRCCameraSynchronizer v0.1.1

### DIFF
--- a/Scripts/Editor/VRCCameraComponentEditor.cs
+++ b/Scripts/Editor/VRCCameraComponentEditor.cs
@@ -43,7 +43,7 @@ namespace Astearium.VRChat.Camera.Editor
         private SerializedProperty _showFocus;
         private SerializedProperty _streaming;
         private SerializedProperty _rollWhileFlying;
-        private SerializedProperty _orientationIsLandscape;
+        private SerializedProperty _orientation;
         private SerializedProperty _poseTransform;
         private SerializedProperty _syncPoseFromTransform;
         private SerializedProperty _syncUnityCamera;
@@ -92,7 +92,7 @@ namespace Astearium.VRChat.Camera.Editor
             _showFocus = serializedObject.FindProperty(VRCCameraComponent.ShowFocusFieldName);
             _streaming = serializedObject.FindProperty(VRCCameraComponent.StreamingFieldName);
             _rollWhileFlying = serializedObject.FindProperty(VRCCameraComponent.RollWhileFlyingFieldName);
-            _orientationIsLandscape = serializedObject.FindProperty(VRCCameraComponent.OrientationFieldName);
+            _orientation = serializedObject.FindProperty(VRCCameraComponent.OrientationFieldName);
             _poseTransform = serializedObject.FindProperty(VRCCameraComponent.PoseSourceFieldName);
             _syncPoseFromTransform = serializedObject.FindProperty(VRCCameraComponent.SyncPoseFromTransformFieldName);
             _syncUnityCamera = serializedObject.FindProperty(VRCCameraComponent.SyncUnityCameraFieldName);
@@ -301,13 +301,12 @@ namespace Astearium.VRChat.Camera.Editor
                     _mode.intValue = (int)modeOrder[newIndex];
                 }
 
-                var currentOrientation =
-                    _orientationIsLandscape.boolValue ? Orientation.Landscape : Orientation.Portrait;
+                var currentOrientation = (Orientation)_orientation.enumValueIndex;
                 EditorGUI.BeginChangeCheck();
                 var newOrientation = (Orientation)EditorGUILayout.EnumPopup("Orientation", currentOrientation);
                 if (EditorGUI.EndChangeCheck())
                 {
-                    _orientationIsLandscape.boolValue = newOrientation == Orientation.Landscape;
+                    _orientation.enumValueIndex = (int)newOrientation;
                 }
 
                 EditorGUILayout.Slider(_exposure, Exposure.MinValue, Exposure.MaxValue, "Exposure");


### PR DESCRIPTION
## Summary
- Cut the v0.1.1 patch release for VRCCameraSynchronizer to address the OSC orientation flag regression reported in issue #20.
- Ensure the Inspector writes the correct `Orientation` enum so `/usercamera/OrientationIsLandscape` now reflects the true Landscape/Portrait selection while keeping the existing runtime pipeline unchanged.

## Key Changes
- **Editor**: Updated `Scripts/Editor/VRCCameraComponentEditor.cs` to bind the `orientation` serialized property as an enum (`enumValueIndex`) instead of a boolean surrogate, eliminating the flipped Landscape/Portrait values and the resulting OSC inversion.
- **Release**: Document v0.1.1 as a hotfix so creators understand the Inspector toggle now aligns with OSC consumers.

## Testing
- [x] Manual - Toggle Orientation in the Inspector and verify `/usercamera/OrientationIsLandscape` outputs `true` for Landscape and `false` for Portrait.

## Release Notes (v0.1.1)
- Fixes the Orientation toggle so selecting Landscape in the Inspector emits `/usercamera/OrientationIsLandscape = true` and keeps `VRCCamera.Orientation` in sync.
